### PR TITLE
feat(auth): forced password change for migrated users

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -19,6 +19,8 @@ export interface AuthUser {
   emailVerified: boolean
   phoneVerified: boolean
   pendingPhone: string | null
+  /** Usuarios migrados (evento 24) arrancan con pass temporal: se les fuerza a definir una nueva. */
+  mustChangePassword: boolean
 }
 
 export type AuthStatus = 'loading' | 'authenticated' | 'unauthenticated'
@@ -31,7 +33,8 @@ const toAuthUser = (u: User): AuthUser => ({
   phone: u.phone ?? null,
   emailVerified: Boolean(u.email_confirmed_at),
   phoneVerified: Boolean(u.phone_confirmed_at),
-  pendingPhone: (u.user_metadata?.pending_phone as string | undefined) ?? null
+  pendingPhone: (u.user_metadata?.pending_phone as string | undefined) ?? null,
+  mustChangePassword: Boolean(u.user_metadata?.must_change_password)
 })
 
 export interface RegisterInput {
@@ -58,6 +61,8 @@ interface AuthContextValue {
   resendOtp: (identifier: string, channel: 'email' | 'sms') => Promise<void>
   forgotPassword: (email: string) => Promise<void>
   resetPassword: (password: string, passwordConfirmation: string) => Promise<void>
+  /** Cambio de pass forzado para usuarios migrados: setea la nueva y limpia must_change_password. */
+  changePassword: (password: string) => Promise<void>
   refresh: () => Promise<void>
 }
 
@@ -181,6 +186,16 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     if (error) throw error
   }, [])
 
+  // Cambio forzado (usuarios migrados): define la pass nueva y limpia el flag en la
+  // misma llamada, así el gate deja de rebotar a /change-password.
+  const changePassword = useCallback(async (password: string) => {
+    const { error } = await requireSupabase().auth.updateUser({
+      password,
+      data: { must_change_password: false }
+    })
+    if (error) throw error
+  }, [])
+
   const refresh = useCallback(async () => {
     const { data } = await requireSupabase().auth.getSession()
     applySession(data.session)
@@ -199,6 +214,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       resendOtp,
       forgotPassword,
       resetPassword,
+      changePassword,
       refresh
     }),
     [
@@ -213,6 +229,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       resendOtp,
       forgotPassword,
       resetPassword,
+      changePassword,
       refresh
     ]
   )

--- a/src/pages/v2/ChangePasswordV2.tsx
+++ b/src/pages/v2/ChangePasswordV2.tsx
@@ -1,0 +1,87 @@
+import { useState, type FormEvent } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+import { useAuth } from '../../context/AuthContext'
+import AuthShell, { Field, inputClass } from '../../components/v2/auth/AuthShell'
+import { Button, useToast } from '../../components/ui'
+
+/**
+ * Cambio de contraseña forzado para usuarios migrados (evento 24). Entraron con una
+ * pass temporal enviada por mail; el gate de Router los trae acá hasta que definan
+ * una nueva. Al guardar se limpia must_change_password y siguen a su destino.
+ */
+export default function ChangePasswordV2() {
+  const { changePassword, refresh } = useAuth()
+  const navigate = useNavigate()
+  const location = useLocation()
+  const toast = useToast()
+
+  const returnTo = (location.state as { returnTo?: string } | null)?.returnTo ?? '/'
+  const [password, setPassword] = useState('')
+  const [passwordConfirmation, setPasswordConfirmation] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    if (password !== passwordConfirmation) {
+      toast.show({ variant: 'warn', title: 'Check the form', message: 'Passwords do not match.' })
+      return
+    }
+    setSubmitting(true)
+    try {
+      await changePassword(password)
+      // Refrescamos el user para que mustChangePassword quede en false antes de salir;
+      // si no, el gate del Router rebota de nuevo a esta pantalla.
+      await refresh()
+      toast.show({
+        variant: 'success',
+        title: 'Password updated',
+        message: 'Your account is ready.'
+      })
+      navigate(returnTo, { replace: true })
+    } catch (err) {
+      toast.show({
+        variant: 'error',
+        message: err instanceof Error ? err.message : 'Could not update the password. Try again.'
+      })
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <AuthShell
+      title='Set your password'
+      subtitle='You logged in with a temporary password. Choose a new one to finish setting up your account.'
+    >
+      <form onSubmit={handleSubmit} className='space-y-4'>
+        <Field label='New password'>
+          <input
+            type='password'
+            required
+            minLength={8}
+            autoComplete='new-password'
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder='At least 8 characters'
+            className={inputClass}
+          />
+        </Field>
+        <Field label='Confirm new password'>
+          <input
+            type='password'
+            required
+            minLength={8}
+            autoComplete='new-password'
+            value={passwordConfirmation}
+            onChange={(e) => setPasswordConfirmation(e.target.value)}
+            placeholder='Repeat your password'
+            className={inputClass}
+          />
+        </Field>
+        <Button type='submit' variant='primary' size='lg' fullWidth disabled={submitting}>
+          {submitting ? 'Saving…' : 'Save and continue'}
+        </Button>
+      </form>
+    </AuthShell>
+  )
+}

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -7,6 +7,7 @@ import VerifyEmailV2 from '../pages/v2/VerifyEmailV2'
 import VerifyPhoneV2 from '../pages/v2/VerifyPhoneV2'
 import ForgotPasswordV2 from '../pages/v2/ForgotPasswordV2'
 import ResetPasswordV2 from '../pages/v2/ResetPasswordV2'
+import ChangePasswordV2 from '../pages/v2/ChangePasswordV2'
 import DesignCheck from '../pages/v2/_DesignCheck'
 import LayoutCheck from '../pages/v2/_LayoutCheck'
 import HomeV2 from '../pages/v2/HomeV2'
@@ -58,6 +59,11 @@ const VerifiedGate = () => {
   if (user && !user.phoneVerified) {
     return <Navigate to='/verify-phone' state={{ returnTo }} replace />
   }
+  // Usuarios migrados (evento 24): entraron con pass temporal, se les fuerza a
+  // definir una nueva antes de dejarlos navegar.
+  if (user && user.mustChangePassword) {
+    return <Navigate to='/change-password' state={{ returnTo }} replace />
+  }
   return <Outlet />
 }
 
@@ -94,6 +100,7 @@ export const AppRouter = () => (
           <Route path='/verify-phone' element={<VerifyPhoneV2 />} />
           <Route path='/forgot-password' element={<ForgotPasswordV2 />} />
           <Route path='/reset-password' element={<ResetPasswordV2 />} />
+          <Route path='/change-password' element={<ChangePasswordV2 />} />
 
           <Route path='/footer/contact' element={<ContactV2 />} />
           <Route path='/footer/terms&conditions' element={<TermsV2 />} />


### PR DESCRIPTION
Usuarios migrados del evento 24 entran con una contraseña temporal enviada por mail y deben definir una nueva antes de navegar.

## Cambios
- **AuthContext**: nuevo flag `mustChangePassword` leído de `user_metadata.must_change_password`; método `changePassword(password)` que setea la pass nueva y limpia el flag en una sola llamada a `updateUser`.
- **Router (VerifiedGate)**: tras verificar email y teléfono, si `mustChangePassword` redirige a `/change-password`.
- **ChangePasswordV2**: pantalla nueva que define la contraseña, refresca la sesión y continúa al destino original.

## Flujo del usuario migrado
1. Login con pass temporal (email ya confirmado).
2. Gate → /verify-phone (agrega teléfono + OTP SMS).
3. Gate → /change-password (define pass nueva, limpia flag).
4. Ve sus tickets del evento 24 (match por `orders.email`).

Typecheck: `tsc --noEmit` sin errores.