### PR TITLE
fix(auth): surface error when email already registered

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -104,7 +104,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   }, [applySession])
 
   const register = useCallback(async (input: RegisterInput) => {
-    const { error } = await requireSupabase().auth.signUp({
+    const { data, error } = await requireSupabase().auth.signUp({
       email: input.email,
       password: input.password,
       options: {
@@ -118,6 +118,12 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       }
     })
     if (error) throw error
+    // Con confirmación de email activada, Supabase NO devuelve error si el email ya
+    // existe (protección anti-enumeración): retorna un user obfuscado con identities
+    // vacío. Sin este chequeo el registro parecía exitoso con un email ya usado.
+    if (data.user && (data.user.identities?.length ?? 0) === 0) {
+      throw new Error('That email is already registered. Try logging in instead.')
+    }
   }, [])
 
   const login = useCallback(async (email: string, password: string) => {


### PR DESCRIPTION
El registro con un email ya usado no mostraba error: parecía exitoso y navegaba a verify-email.

## Causa
Con la confirmación de email activada, Supabase `signUp` **no devuelve error** si el email ya existe (protección anti-enumeración). Devuelve un user obfuscado con `identities: []`. El código solo miraba `error`, así que el alta parecía correcta.

## Fix
Detectar `data.user.identities.length === 0` y lanzar un error para que el formulario muestre el aviso en vez de avanzar.

Typecheck: `tsc --noEmit` sin errores.