### PR TITLE
feat: disable phone verification

### DIFF
--- a/src/pages/v2/RegisterV2.tsx
+++ b/src/pages/v2/RegisterV2.tsx
@@ -66,7 +66,7 @@ export default function RegisterV2() {
   return (
     <AuthShell
       title='Create your account'
-      subtitle="You'll need to verify your email and phone before you can log in."
+      subtitle="You'll need to verify your email before you can log in."
       footer={
         <>
           Already have an account?{' '}

--- a/src/pages/v2/VerifyEmailV2.tsx
+++ b/src/pages/v2/VerifyEmailV2.tsx
@@ -13,7 +13,6 @@ export default function VerifyEmailV2() {
 
   const state = location.state as { email?: string; phone?: string; returnTo?: string } | null
   const stateEmail = state?.email ?? ''
-  const statePhone = state?.phone ?? ''
   const returnTo = state?.returnTo
   const [email, setEmail] = useState(stateEmail)
   const [code, setCode] = useState('')
@@ -28,9 +27,10 @@ export default function VerifyEmailV2() {
       toast.show({
         variant: 'success',
         title: 'Email verified',
-        message: "Now let's confirm your phone number."
+        message: 'Your account is ready.'
       })
-      navigate('/verify-phone', { state: { phone: statePhone, returnTo } })
+      // ponytail: verificación de teléfono deshabilitada — vamos directo al destino
+      navigate(returnTo || '/', { replace: true })
     } catch (err) {
       toast.show({
         variant: 'error',

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -46,7 +46,8 @@ const SaleRoute = () => {
   return label ? <SaleV2 eventLabel={label} eventId={eid} /> : <Navigate to='/events' />
 }
 
-/** Si hay sesión, debe estar verificada (email Y teléfono). Anónimo pasa. */
+/** Si hay sesión, debe tener el email verificado. Anónimo pasa.
+ *  ponytail: verificación de teléfono deshabilitada — ya no se exige phoneVerified. */
 const VerifiedGate = () => {
   const { status, user } = useAuth()
   const location = useLocation()
@@ -54,9 +55,6 @@ const VerifiedGate = () => {
   if (status === 'loading') return null
   if (user && !user.emailVerified) {
     return <Navigate to='/verify-email' state={{ email: user.email, returnTo }} replace />
-  }
-  if (user && !user.phoneVerified) {
-    return <Navigate to='/verify-phone' state={{ returnTo }} replace />
   }
   return <Outlet />
 }


### PR DESCRIPTION
## Qué

Deshabilita la verificación de teléfono en toda la app (solo frontend).

## Cambios

- **`router/Router.tsx`** — `VerifiedGate` ya no redirige a `/verify-phone` cuando `phoneVerified` es `false`. Navegar con sesión iniciada solo exige el email verificado.
- **`pages/v2/VerifyEmailV2.tsx`** — tras verificar el email se navega directo a `returnTo || '/'` en vez de encadenar a `/verify-phone`. Se quitó `statePhone` sin uso.
- **`pages/v2/RegisterV2.tsx`** — el subtítulo ya no menciona el teléfono.

## No incluido (a propósito)

- La ruta `/verify-phone` y la página `VerifyPhoneV2` siguen montadas (accesibles manualmente desde el perfil).
- El campo de teléfono en el registro se sigue capturando; solo se deja de exigir su verificación.

## Verificación

- Registrar → verificar email → entra directo, sin pantalla de teléfono.
- Navegar logueado con teléfono sin verificar ya no redirige a `/verify-phone`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)