### PR TITLE
feat: forzar cambio de contraseña a usuarios migrados

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -19,6 +19,8 @@ export interface AuthUser {
   emailVerified: boolean
   phoneVerified: boolean
   pendingPhone: string | null
+  /** true para usuarios migrados con contraseña temporal; el gate fuerza el cambio. */
+  mustChangePassword: boolean
 }
 
 export type AuthStatus = 'loading' | 'authenticated' | 'unauthenticated'
@@ -31,7 +33,8 @@ const toAuthUser = (u: User): AuthUser => ({
   phone: u.phone ?? null,
   emailVerified: Boolean(u.email_confirmed_at),
   phoneVerified: Boolean(u.phone_confirmed_at),
-  pendingPhone: (u.user_metadata?.pending_phone as string | undefined) ?? null
+  pendingPhone: (u.user_metadata?.pending_phone as string | undefined) ?? null,
+  mustChangePassword: u.user_metadata?.must_change_password === true
 })
 
 export interface RegisterInput {
@@ -177,7 +180,12 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   }, [])
 
   const resetPassword = useCallback(async (password: string, _passwordConfirmation: string) => {
-    const { error } = await requireSupabase().auth.updateUser({ password })
+    // Limpiamos must_change_password: cubre el reset normal y el cambio forzado
+    // de usuarios migrados (el gate deja de redirigir tras esto).
+    const { error } = await requireSupabase().auth.updateUser({
+      password,
+      data: { must_change_password: false }
+    })
     if (error) throw error
   }, [])
 

--- a/src/pages/v2/ResetPasswordV2.tsx
+++ b/src/pages/v2/ResetPasswordV2.tsx
@@ -5,7 +5,7 @@ import AuthShell, { Field, inputClass } from '../../components/v2/auth/AuthShell
 import { Button, useToast } from '../../components/ui'
 
 export default function ResetPasswordV2() {
-  const { resetPassword } = useAuth()
+  const { resetPassword, status } = useAuth()
   const navigate = useNavigate()
   const toast = useToast()
 
@@ -27,7 +27,8 @@ export default function ResetPasswordV2() {
         title: 'Password updated',
         message: 'You can now log in with your new password.'
       })
-      navigate('/login')
+      // Cambio forzado (usuario migrado ya autenticado) -> home; recovery sin sesion -> login.
+      navigate(status === 'authenticated' ? '/' : '/login')
     } catch (err) {
       toast.show({
         variant: 'error',

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -55,6 +55,10 @@ const VerifiedGate = () => {
   if (user && !user.emailVerified) {
     return <Navigate to='/verify-email' state={{ email: user.email, returnTo }} replace />
   }
+  // Usuarios migrados con contraseña temporal: forzar cambio antes de seguir.
+  if (user && user.mustChangePassword) {
+    return <Navigate to='/reset-password' replace />
+  }
   return <Outlet />
 }
 


### PR DESCRIPTION
## Qué

Fuerza el cambio de contraseña a los usuarios migrados (evento 24, Auth0 → Supabase) que se crean con una contraseña temporal.

## Problema

El script de migración crea los usuarios con `user_metadata.must_change_password = true`, pero **ningún código del frontend leía ese flag**. Resultado: el usuario podía loguearse con la contraseña temporal y usar la app sin cambiarla (verificado con una cuenta de prueba).

## Cambios

- **`AuthContext`**: expone `mustChangePassword` (desde `user_metadata`). `resetPassword` ahora limpia el flag al setear la nueva contraseña (una sola vez, cubre reset por email y cambio forzado).
- **`VerifiedGate` (Router)**: redirige a `/reset-password` mientras el flag esté activo.
- **`ResetPasswordV2`**: tras el cambio, un usuario ya autenticado (flujo forzado) va a `/`; el recovery por email sin sesión sigue yendo a `/login`.

3 archivos, sin dependencias nuevas. `tsc --noEmit` en verde.

## Cómo probar

1. Deploy.
2. Login con una cuenta migrada (temporal password).
3. Debe redirigir a `/reset-password` y no dejar avanzar hasta cambiarla.
4. Tras cambiarla, entra normal; re-login con la temporal ya no funciona.

## Nota

El gate cubre `/` y todo el flujo real (post-login caen en `/`). Páginas públicas sueltas (`/about`, `/faqs`) no fuerzan el cambio — no es el flujo de entrada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)