### PR TITLE
fix(event): venue/ciudad/mapa desde settings.location_details + JSON en errores del proxy

### DIFF
--- a/netlify/functions/proxy-api.js
+++ b/netlify/functions/proxy-api.js
@@ -61,7 +61,10 @@ exports.handler = async (event) => {
   const url = `${API_ORIGIN}${normalizedPath}${queryString}`
 
   try {
-    const headers = { 'Content-Type': 'application/json' }
+    // Accept explícito: sin él Laravel cree que no se espera JSON y en errores
+    // (422 validación, 401 auth) REDIRIGE al SPA de login en vez de devolver JSON
+    // el front recibía HTML y mostraba "No pudimos reservar".
+    const headers = { 'Content-Type': 'application/json', Accept: 'application/json' }
     if (event.headers.authorization) {
       // JWT de Supabase del cliente (endpoints /public/... con auth:customer).
       headers['Authorization'] = event.headers.authorization

--- a/src/pages/v2/EventDetailV2.tsx
+++ b/src/pages/v2/EventDetailV2.tsx
@@ -189,7 +189,8 @@ export default function EventDetailV2() {
     new Date(detail.end_date).getTime() > new Date(detail.start_date).getTime()
       ? fmtTimeInTz(detail.end_date, detail.timezone)
       : ''
-  const address = formatAddress(detail?.location_details)
+  // La dirección vive en settings.location_details (el top-level viene null).
+  const address = formatAddress(detail?.settings?.location_details ?? detail?.location_details)
   const organizerName = detail?.organizer?.name
 
   const dates = useMemo(() => getDatesForEvent(visible, event), [visible, event])
@@ -343,7 +344,10 @@ export default function EventDetailV2() {
 
       <Section title='Good to know'>
         <div className='grid grid-cols-2 sm:grid-cols-4 gap-2'>
-          <FactPill label='Doors' value={event.time || 'TBA'} />
+          {/* event.time es la hora de INICIO del show, no la de puertas. Antes se
+              rotulaba "Doors" (engañoso). Para puertas reales, agregar un campo
+              público "Doors" en el panel (Campos adicionales) → sale abajo. */}
+          <FactPill label='Start' value={event.time || 'TBA'} />
           {/* Campos custom públicos cargados desde el admin (attributes). */}
           {(detail?.attributes ?? []).map((attr) => (
             <FactPill key={attr.name} label={attr.name} value={String(attr.value ?? '')} />

--- a/src/services/hiEventsAdapter.ts
+++ b/src/services/hiEventsAdapter.ts
@@ -176,9 +176,12 @@ const buildDetailHref = (hi: HiEventPublic): string =>
 export const hiEventToUIEvent = (hi: HiEventPublic, context: { hero?: boolean } = {}): UIEvent => {
   const parts = toDateParts(hi.start_date, hi.timezone)
   const category = resolveCategory(hi.category, hi.title)
-  const venueName = hi.location_details?.venue_name ?? ''
-  const city = hi.location_details?.city ?? ''
-  const country = hi.location_details?.country ?? ''
+  // La Location del panel vive en settings.location_details; el top-level
+  // location_details del evento viene null. Leer settings primero.
+  const loc = hi.settings?.location_details ?? hi.location_details
+  const venueName = loc?.venue_name ?? ''
+  const city = loc?.city ?? ''
+  const country = loc?.country ?? ''
   const venueLabel = venueName ? slugify(venueName) : hi.slug
   // Sin inventar: si no hay venue/ciudad, subtítulo y venueName quedan vacíos
   // (no se cae al slug ni al título). La UI los oculta.

--- a/src/types/hievents.ts
+++ b/src/types/hievents.ts
@@ -56,6 +56,9 @@ export interface HiEventSettings {
   website_url: string | null
   maps_url: string | null
   is_online_event: boolean
+  // La Location del panel se guarda acá (event_settings), NO en el top-level
+  // location_details del evento (ese viene null). Fuente de verdad de venue/ciudad.
+  location_details?: HiLocationDetails | null
   [key: string]: unknown
 }
 


### PR DESCRIPTION
## Qué

Cuatro fixes del sitio comprador (v2), reportados sobre el evento *Las Alucines* (San Jose Civic).

### Raíz común (venue/ciudad/mapa vacíos)
La Location cargada en el panel (`venue_name`, `city`, `address`) se guarda en **`settings.location_details`**; el `location_details` top-level del evento viene **`null`**. El adapter y `EventDetailV2` leían el top-level → quedaban vacíos:

- **Carrusel home**: card sin venue/ciudad (solo título + fecha).
- **Detalle**: pin del rect de fecha vacío.
- **Mapa "Location"**: el iframe se armaba con `?q=` (query vacía) → Google mostraba el mundo entero.

Fix: leer `settings.location_details` primero.

### Errores del proxy volvían como HTML
El proxy Netlify (`proxy-api.js`) no reenviaba `Accept: application/json`. Sin él Laravel asume que no se espera JSON y en errores (422 validación, 401 auth) **redirige al SPA de login** → el front recibía HTML y mostraba *"No pudimos reservar"* genérico. Ahora se envía `Accept: application/json`.

### "Doors" engañoso
El `FactPill` "Doors" mostraba `event.time` = hora de **inicio** del show (8:30 PM), no la de puertas. Se renombra a **"Start"**. Para puertas reales, agregar un campo público en **panel → Campos adicionales** (ya se renderiza vía `detail.attributes`).

## Archivos
- `src/services/hiEventsAdapter.ts` — venue/ciudad/país desde `settings.location_details`
- `src/pages/v2/EventDetailV2.tsx` — `address` desde `settings.location_details`; pill `Start`
- `src/types/hievents.ts` — tipado `settings.location_details`
- `netlify/functions/proxy-api.js` — `Accept: application/json` upstream

## Verificación
- `npx tsc --noEmit` → 0 errores.
- Respuesta real de `/public/events/24` confirmada: `settings.location_details = {San Jose Civic, San Jose, 135 W San Carlos St}`, top-level `null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)