### PR TITLE
feat: ver tickets de una compra desde el mail + fixes seatmap/location

### DIFF
--- a/src/assets/venue-maps/miami.ranges.json
+++ b/src/assets/venue-maps/miami.ranges.json
@@ -16,7 +16,11 @@
       "balconyrightcenter-blue-DD",
       "balconyright-blue-GG"
     ],
-    "reversed_sections": ["leftcenter-green", "leftcenter-pink", "leftcenter-yellow"],
+    "reversed_sections": [
+      "leftcenter-green",
+      "leftcenter-pink",
+      "leftcenter-yellow"
+    ],
     "seat_types": {
       "wheelchair": [
         "4-leftcenter-yellow-A",
@@ -54,7 +58,8 @@
       "rightcenter-green": 58,
       "rightcenter-pink": 66,
       "rightcenter-yellow": 31
-    }
+    },
+    "stage_direction": "south"
   },
   "balconyleft-blue-HH": "1-10",
   "balconyleft-blue-GG": "3-10",

--- a/src/pages/v2/TicketReceivedV2.tsx
+++ b/src/pages/v2/TicketReceivedV2.tsx
@@ -96,8 +96,8 @@ export default function TicketReceivedV2() {
     if (confirmRan.current || !venueId || !orderShortId) return
     confirmRan.current = true
     ;(async () => {
+      const sessionId = extractSessionId()
       try {
-        const sessionId = extractSessionId()
         if (sessionId) {
           for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
             try {
@@ -116,10 +116,14 @@ export default function TicketReceivedV2() {
       } catch {
         // El pago igual se confirma vía webhook de HiEvents; no bloqueamos la UI.
       } finally {
-        try {
-          localStorage.removeItem('local_cart')
-        } catch {}
-        clearCart()
+        // Solo limpiar el carrito tras un checkout real (hay sessionId). En una
+        // visita desde el mail (sin sessionId) no tocamos el carrito activo.
+        if (sessionId) {
+          try {
+            localStorage.removeItem('local_cart')
+          } catch {}
+          clearCart()
+        }
       }
     })()
   }, [venueId, orderShortId, clearCart])

--- a/src/pages/v2/dashboardTabs/UpcomingV2.tsx
+++ b/src/pages/v2/dashboardTabs/UpcomingV2.tsx
@@ -1,30 +1,73 @@
-import { useMemo } from 'react'
-import { useOutletContext } from 'react-router-dom'
+import { useEffect, useMemo, useState } from 'react'
+import { useOutletContext, useSearchParams } from 'react-router-dom'
 import TicketGrid from '../../../components/v2/ticket/TicketGrid'
 import { userTicketsEventToUIEvent } from '../../../services/hiEventsAdapter'
+import { hiEventsService } from '../../../services/hiEventsService'
 import type { MyTicketsContext } from '../MyTicketsV2'
 import { ticketHref, TicketListSkeleton } from './_shared'
 
 /**
  * Tickets próximos del usuario (eventos con fecha futura), reales de HiEvents.
  * Una card por evento; el link lleva a su ticketera pública (QR real).
+ *
+ * Con `?event=<id>&order=<shortId>` (link de los mails de compra) filtramos a
+ * los tickets de esa orden: resolvemos la orden y cruzamos sus `public_id` con
+ * los `ticketId` del usuario.
  */
 export default function UpcomingV2() {
   const { upcoming, loading } = useOutletContext<MyTicketsContext>()
+  const [params] = useSearchParams()
+  const orderShortId = params.get('order')
+  const eventId = params.get('event')
 
-  const events = useMemo(() => upcoming.map(userTicketsEventToUIEvent), [upcoming])
+  const [orderTicketIds, setOrderTicketIds] = useState<Set<string> | null>(null)
+  const [orderLoading, setOrderLoading] = useState(false)
+  useEffect(() => {
+    if (!orderShortId || !eventId) {
+      setOrderTicketIds(null)
+      return
+    }
+    const controller = new AbortController()
+    setOrderLoading(true)
+    hiEventsService
+      .getOrder(eventId, orderShortId, controller.signal)
+      .then((ord) => {
+        const ids = (ord?.attendees ?? []).map((a) => a.public_id).filter(Boolean)
+        setOrderTicketIds(new Set(ids))
+      })
+      .catch(() => {
+        if (!controller.signal.aborted) setOrderTicketIds(new Set()) // orden no hallada → vacío
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setOrderLoading(false)
+      })
+    return () => controller.abort()
+  }, [orderShortId, eventId])
+
+  const filtered = useMemo(() => {
+    if (!orderTicketIds) return upcoming
+    return upcoming
+      .map((e) => ({ ...e, tickets: e.tickets.filter((t) => orderTicketIds.has(t.ticketId)) }))
+      .filter((e) => e.tickets.length > 0)
+  }, [upcoming, orderTicketIds])
+
+  const events = useMemo(() => filtered.map(userTicketsEventToUIEvent), [filtered])
   const hrefBySlug = useMemo(
-    () => new Map(upcoming.map((e) => [e.eventId, ticketHref(e)])),
-    [upcoming]
+    () => new Map(filtered.map((e) => [e.eventId, ticketHref(e)])),
+    [filtered]
   )
 
-  if (loading) return <TicketListSkeleton />
+  if (loading || orderLoading) return <TicketListSkeleton />
 
   return (
     <TicketGrid
       events={events}
       hrefFor={(e) => hrefBySlug.get(e.id)}
-      emptyMessage="You don't have any upcoming events yet — browse and grab some."
+      emptyMessage={
+        orderTicketIds
+          ? 'No encontramos los tickets de esta compra.'
+          : "You don't have any upcoming events yet — browse and grab some."
+      }
     />
   )
 }


### PR DESCRIPTION
## Qué

El botón "View Order Summary & Tickets" del mail de compra ahora lleva al dashboard de tickets del comprador, filtrado a esa compra.

### Cambios de este flujo
- **UpcomingV2**: con `?event=<id>&order=<shortId>` resuelve la orden (`getOrder`), saca los `public_id` de los attendees y los cruza con los `ticketId` del usuario → muestra solo los tickets de esa compra. Sin params, comportamiento normal (todos los upcoming).
- **TicketReceivedV2** (`/checkout/:venueId/:orderShortId/success`): el `clearCart` + borrado de `local_cart` ahora solo corre tras un checkout real (hay `sessionId`); en visitas de solo-lectura no toca el carrito activo.

Login redirect-back ya funciona vía `RequireAuth` (`returnTo`) + `LoginV2`.

> Nota: la rama incluye además commits previos de seatmap Miami y fixes de event-location/JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)