### PR TITLE
fix(sale): SVG del mapa se ajusta al recuadro (ancho y alto)

### DIFF
--- a/src/components/v2/sale/SeatingMapV2.tsx
+++ b/src/components/v2/sale/SeatingMapV2.tsx
@@ -1317,7 +1317,7 @@ export default function SeatingMapV2({
             ariaLabel='Venue map. Scroll or pinch to zoom, drag to pan. Click a section to view its seats.'
           >
             <div
-              className='w-[min(94vw,1000px)]'
+              className='flex h-[380px] w-[min(94vw,1000px)] items-center justify-center sm:h-[480px] lg:h-[620px]'
               dangerouslySetInnerHTML={{
                 __html: svgContent
                   .replace(/<title[\s\S]*?<\/title>/gi, '')
@@ -1325,7 +1325,10 @@ export default function SeatingMapV2({
                   .replace(/\s+title="[^"]*"/gi, '')
                   .replace(
                     /<svg([^>]*)>/gi,
-                    '<svg$1 style="width: 100%; height: auto; max-width: 100%; user-select: none; -webkit-user-select: none;" class="w-full h-auto" preserveAspectRatio="xMidYMid meet">'
+                    // Ajusta al recuadro por ancho Y alto (letterbox). El wrapper tiene alto
+                    // definido (= ZoomPanContainer), así max-height:100% resuelve. Sin esto,
+                    // mapas altos/angostos (Miami) desbordan el alto y se recortan.
+                    '<svg$1 style="max-width: 100%; max-height: 100%; width: auto; height: auto; user-select: none; -webkit-user-select: none;" class="max-w-full max-h-full" preserveAspectRatio="xMidYMid meet">'
                   )
               }}
             />


### PR DESCRIPTION
## Qué

El SVG del mapa de asientos se inyectaba con `width:100%; height:auto`, así que solo se ajustaba por **ancho**. Mapas altos/angostos como Miami (1444×1869) desbordaban el alto fijo del recuadro y `overflow-hidden` los recortaba. Los mapas anchos/cuadrados no se notaban.

## Cambio

En `SeatingMapV2.tsx`:
- El wrapper del SVG ahora tiene **alto definido** = `ZoomPanContainer` (`h-[380px] sm:h-[480px] lg:h-[620px]`) + `flex items-center justify-center`.
- El SVG hace letterbox: `max-width:100%; max-height:100%; width:auto; height:auto` + `preserveAspectRatio="xMidYMid meet"`.

Ahora todos los mapas entran completos por ancho **y** alto. Sin depender de `viewBox` (usa el ratio intrínseco).

## Verificación

- `tsc --noEmit`: sin errores.
- Repro: `/sale/Test%20Miami/manuel-artime-theater/Miami/2026-10-25/test-miami/null?eid=25` → mapa Miami entra completo en el recuadro, no recortado.