### PR TITLE
fix(sale): filas ordenadas por cercanía al escenario

### DIFF
--- a/src/components/v2/sale/SeatPickerV2.tsx
+++ b/src/components/v2/sale/SeatPickerV2.tsx
@@ -452,6 +452,14 @@ export default function SeatPickerV2({
           ? 'flex-row'
           : 'flex-row-reverse'
 
+  // Proximidad fila↔escenario: por convención la fila menor (A/1) es la de adelante,
+  // pegada al escenario. gridRows viene en orden ascendente (A→Z), que deja A junto al
+  // escenario cuando éste está arriba/izquierda. Cuando el escenario está abajo/derecha
+  // invertimos para que A quede en ese borde (más cerca) y Z al fondo.
+  // ponytail: asume A=frente. Si un mapa numera al revés, agregar metadata `rows_reversed`.
+  const rowsForRender =
+    stagePos === 'bottom' || stagePos === 'right' ? [...gridRows].reverse() : gridRows
+
   const disabledCta = cart.length === 0 || cart.length > MAX_SEATS || confirming
   const ctaLabel = confirming
     ? 'Reservando tus asientos…'
@@ -516,7 +524,7 @@ export default function SeatPickerV2({
 
                 <div className='min-w-0 flex-1 overflow-auto'>
                   <div className='mx-auto flex w-max min-w-full flex-col items-center gap-1.5 py-3'>
-                    {gridRows.map((row) => {
+                    {rowsForRender.map((row) => {
                       const layoutRow = sectionLayout?.[row]
                         ? reversed
                           ? [...sectionLayout[row]].reverse()


### PR DESCRIPTION
## Qué

Las filas se renderizaban siempre en orden ascendente (A→Z) sin importar dónde está el escenario. Con escenario abajo (south, ej. Manuel Artime / Miami) la fila de adelante (A) quedaba **arriba**, la más lejos del escenario — al revés del mapa real (donde A-B-C arrancan desde el escenario).

## Cambio

En `SeatPickerV2`: cuando el escenario está en `bottom`/`right`, se invierte el orden de filas para que la fila de adelante (A/1) quede pegada al borde del escenario y las filas se alejen hacia el fondo.

Convención: **fila A = frente** (derivado de `stage_direction` + orden alfabético). Si a futuro un mapa numera al revés, se agrega un flag en `metadata` (ej. `rows_reversed`); no se construyó ahora para no anticipar (YAGNI).

## Verificación

- `tsc --noEmit`: sin errores.
- Miami (`stage_direction: south`): escenario abajo, fila A abajo pegada al escenario, filas siguientes hacia arriba; asientos rotados mirando al escenario.