### PR TITLE
fix(pricing): mostrar precio más bajo con fees según config del evento

### DIFF
--- a/src/components/v2/sale/SeatingMapV2.tsx
+++ b/src/components/v2/sale/SeatingMapV2.tsx
@@ -307,37 +307,74 @@ export default function SeatingMapV2({
     const defs = Object.values(ranges)
     if (defs.length === 0) return
     let mounted = true
-    const byColor = new Map<string, string>() // color → groupKey representativo
+    // color → groupKey representativo. Balcón/loge se agrupan por ZONA (`balcony-blue`),
+    // no por posición (`balconyleft-blue` no existe como grupo → devolvía 0 asientos y el
+    // color quedaba sin precio). El resto va por posición (`left-green`).
+    const byColor = new Map<string, string>()
     for (const def of defs) {
-      if (def.color && def.position && !byColor.has(def.color)) {
-        byColor.set(def.color, `${def.position}-${def.color}`)
-      }
+      if (!def.color || byColor.has(def.color)) continue
+      const key = def.zone
+        ? `${def.zone}-${def.color}`
+        : def.position
+          ? `${def.position}-${def.color}`
+          : null
+      if (key) byColor.set(def.color, key)
     }
     // Mostrar los colores ya (sin precio); completar el precio en paralelo.
     setLegend([...byColor.keys()].map((color) => ({ color, name: COLOR_LABELS[color] || color })))
-    Promise.all(
-      [...byColor.entries()].map(async ([color, groupKey]) => {
-        try {
-          const gs = await loadGroupSeats(groupKey)
-          const withPrice = gs.find((s) => typeof s.price === 'number')
-          return {
-            color,
-            name: withPrice?.price_range || COLOR_LABELS[color] || color,
-            price: withPrice?.price ?? undefined
+    ;(async () => {
+      // Base + asiento representativo (el más barato) por color.
+      const reps = await Promise.all(
+        [...byColor.entries()].map(async ([color, groupKey]) => {
+          try {
+            const gs = await loadGroupSeats(groupKey)
+            const priced = gs.filter((s) => typeof s.price === 'number')
+            if (priced.length === 0) return { color, name: COLOR_LABELS[color] || color }
+            const min = priced.reduce((a, b) => ((b.price as number) < (a.price as number) ? b : a))
+            return {
+              color,
+              name: min.price_range || COLOR_LABELS[color] || color,
+              price: min.price ?? undefined,
+              seatId: min.id
+            }
+          } catch {
+            return { color, name: COLOR_LABELS[color] || color }
           }
-        } catch {
-          return { color, name: COLOR_LABELS[color] || color, price: undefined }
+        })
+      )
+      // Con fees solo si el evento se configuró INCLUSIVE. /seats no trae el precio con
+      // impuestos → se pide por asiento representativo (1 POST para todos los colores).
+      const ev = await hiEventsService.getEvent(eventId).catch(() => null)
+      const inclusive = ev?.settings?.price_display_mode === 'INCLUSIVE'
+      let inclById = new Map<number, number>()
+      if (inclusive) {
+        const ids = reps
+          .map((r) => (r as { seatId?: number }).seatId)
+          .filter((id): id is number => typeof id === 'number')
+        const pricing = await hiEventsService.getTicketsBySeatIds(eventId, ids).catch(() => [])
+        inclById = new Map(
+          pricing
+            .filter((p) => typeof p.price_including_taxes_and_fees === 'number')
+            .map((p) => [p.id, p.price_including_taxes_and_fees as number])
+        )
+      }
+      if (!mounted) return
+      const rows = reps.map((r) => {
+        const seatId = (r as { seatId?: number }).seatId
+        const base = (r as { price?: number }).price
+        return {
+          color: r.color,
+          name: r.name,
+          price: inclusive && seatId != null ? (inclById.get(seatId) ?? base) : base
         }
       })
-    ).then((rows) => {
-      if (!mounted) return
       rows.sort((a, b) => (a.price ?? Infinity) - (b.price ?? Infinity))
       setLegend(rows)
-    })
+    })()
     return () => {
       mounted = false
     }
-  }, [ranges, loadGroupSeats])
+  }, [ranges, loadGroupSeats, eventId])
 
   const sectionStats = useMemo(() => {
     const bySection: Record<string, { total: number; available: number; position?: string }> = {}

--- a/src/pages/v2/EventDetailV2.tsx
+++ b/src/pages/v2/EventDetailV2.tsx
@@ -120,13 +120,15 @@ export default function EventDetailV2() {
   // Evento base: de la lista (rápido) o construido desde el detalle (deep-link).
   const baseEvent: UIEvent | null = eventFromList ?? (detail ? hiEventToUIEvent(detail) : null)
 
-  // priceFrom real: mínimo con impuestos de los tickets.
+  // priceFrom real: mínimo de los tickets. Con fees solo si el evento se configuró
+  // INCLUSIVE (price_display_mode); si no, precio base.
+  const priceInclusive = detail?.settings?.price_display_mode === 'INCLUSIVE'
   const priceFrom = useMemo(() => {
     const all = tickets.flatMap((t) =>
-      t.prices.map((p) => p.price_including_taxes_and_fees ?? p.price)
+      t.prices.map((p) => (priceInclusive ? (p.price_including_taxes_and_fees ?? p.price) : p.price))
     )
     return all.length > 0 ? Math.min(...all) : null
-  }, [tickets])
+  }, [tickets, priceInclusive])
 
   // Countdown: si ningún ticket está en venta y hay una fecha de apertura futura,
   // mostramos "On sale {fecha}" (la más temprana) y se deshabilita la compra.

--- a/src/services/hiEventsService.ts
+++ b/src/services/hiEventsService.ts
@@ -272,8 +272,11 @@ export const hiEventsService = {
    * una muestra para el "desde $"). Si un general supera 100 tipos, ver deuda técnica.
    */
   async getTickets(eventId: string | number, signal?: AbortSignal): Promise<HiTicketPublic[]> {
+    // ponytail: 1 página de 1000. Eventos enumerados modelan 1 ticket por asiento
+    // (~866 en Miami); con per_page=100 el "desde $X" salía del mínimo de la 1ª página,
+    // no el global. Si algún evento supera 1000 tickets, paginar acá.
     const body = await getJson<HiPaginated<HiTicketPublic>>(
-      `${HIEVENTS_CONFIG.endpoints.eventTickets(eventId)}${toQuery({ per_page: 100 })}`,
+      `${HIEVENTS_CONFIG.endpoints.eventTickets(eventId)}${toQuery({ per_page: 1000 })}`,
       signal
     )
     return body.data


### PR DESCRIPTION
## Qué

Dos puntos de precio no reflejaban los fees ni el mínimo real (evento 25 = INCLUSIVE):

1. **Detalle `/event/25/test-miami` — sticky "Choose seats · From \$X"**: no mostraba el precio más bajo. `getTickets` traía solo 100 tickets (`per_page=100`); los eventos enumerados modelan **un ticket por asiento** (~866 en Miami), así que el mínimo salía de la primera página, no del global. Ahora se trae la lista completa en una página (`per_page=1000`) y el mínimo usa fees solo si `settings.price_display_mode === 'INCLUSIVE'`, si no precio base.

2. **Legend del mapa (precios por color)**: se veían **sin fees** y algunos colores **sin precio**.
   - Fees: `/seats` devuelve solo precio base (`price_including_taxes_and_fees` viene `null` ahí). Cuando el evento es INCLUSIVE, el asiento representativo (el más barato) de cada color se cotiza vía `/tickets/by-seat-ids` (un solo POST para todos los colores).
   - Mínimo por color (antes tomaba el primer asiento con precio, no el más barato).
   - Colores sin precio: balcón/loge se agrupan por **zona** (`balcony-blue`), no por posición (`balconyleft-blue` no existía como grupo y devolvía 0 asientos).

## Archivos

- `src/services/hiEventsService.ts` — `getTickets` `per_page` 100 → 1000.
- `src/pages/v2/EventDetailV2.tsx` — `priceFrom` con fees condicionado a `price_display_mode`.
- `src/components/v2/sale/SeatingMapV2.tsx` — legend: groupKey por zona, min por color, fees vía by-seat-ids.

## Verificación

- `tsc --noEmit` limpio.
- Assert de lógica pura (groupKey zona, min por color, mapeo inclusive) OK.
- API evento 25: min base 40 → incl 51.2 (azul); verde 55 → 68.9; grupo `balcony-blue` devuelve asientos, `balconyleft-blue` no.