### PR TITLE
fix(sale): balcony per-side sections + tier-based fee pricing

### DIFF
--- a/src/components/v2/eventDetail/StickyCTA.tsx
+++ b/src/components/v2/eventDetail/StickyCTA.tsx
@@ -65,7 +65,7 @@ export default function StickyCTA({
     return 'Choose seats'
   })()
 
-  const priceLabel = priceFrom !== null ? `From $${Math.round(priceFrom)}` : ''
+  const priceLabel = priceFrom !== null ? `From $${priceFrom.toFixed(2)}` : ''
 
   const queueHref = `/queue/${encodeURIComponent(event.id)}`
 

--- a/src/components/v2/sale/SeatPickerV2.tsx
+++ b/src/components/v2/sale/SeatPickerV2.tsx
@@ -7,13 +7,10 @@ import { CartSidebar, CartMobileSheet, type CartSummaryItem } from './CartSummar
 import { useSessionTimer } from '../../../hooks/useSessionTimer'
 import { validateSeatAddByNumber, type RowSeatInfo } from '../../../hooks/useSeatContiguity'
 import { useCart } from '../../../router/cartContext'
-import {
-  hiEventsService,
-  HiEventsApiError,
-  type HiSeatPricing
-} from '../../../services/hiEventsService'
+import { hiEventsService, HiEventsApiError } from '../../../services/hiEventsService'
 import type { PricingBreakdown } from '../../../lib/pricing'
 import type { UIEvent } from '../../../types/uiEvent'
+import type { HiTicketPrice } from '../../../types/hievents'
 import type { SeatItem } from './seatTypes'
 
 const MAX_SEATS = 10
@@ -91,19 +88,21 @@ export default function SeatPickerV2({
 
   // El mapa masivo NO trae precio (performance). Al abrir la sección traemos el precio
   // + impuestos SOLO de sus asientos (pocos → <0.6s) vía /tickets/by-seat-ids.
-  const [pricing, setPricing] = useState<Map<number, HiSeatPricing>>(new Map())
+  // Precio con fees por TIER (base → tier), no por asiento: el fee depende del tier,
+  // así que una sola llamada /tickets sirve para todos los asientos y todas las
+  // secciones (antes: /tickets/by-seat-ids por sección, topaba a 100 ids).
+  const [tierByBase, setTierByBase] = useState<Map<number, HiTicketPrice>>(new Map())
   const [pricingReady, setPricingReady] = useState(false)
 
   useEffect(() => {
     const controller = new AbortController()
     let mounted = true
     setPricingReady(false)
-    const ids = section.seats.map((s) => s.id)
     hiEventsService
-      .getTicketsBySeatIds(event.eventId, ids, controller.signal)
-      .then((rows) => {
+      .getPriceTiers(event.eventId, controller.signal)
+      .then((map) => {
         if (!mounted) return
-        setPricing(new Map(rows.map((r) => [r.id, r])))
+        setTierByBase(map)
         setPricingReady(true)
       })
       .catch(() => {
@@ -114,7 +113,7 @@ export default function SeatPickerV2({
       mounted = false
       controller.abort()
     }
-  }, [section.seats, event.eventId])
+  }, [event.eventId])
 
   // B1 · Disponibilidad EN VIVO. Refrescamos los asientos de la sección cada ~11s
   // (pausado si la pestaña está oculta). Si un asiento que tenías seleccionado lo
@@ -310,8 +309,8 @@ export default function SeatPickerV2({
     }
 
     setWarning(null)
-    const p = pricing.get(seat.id)
-    const base = p?.price ?? seat.price ?? 0
+    const base = seat.price ?? 0
+    const p = tierByBase.get(base)
     const final = p?.price_including_taxes_and_fees ?? base
     addItem({
       ticketId: `seat-${seat.id}`,

--- a/src/components/v2/sale/SeatingMapV2.tsx
+++ b/src/components/v2/sale/SeatingMapV2.tsx
@@ -122,6 +122,18 @@ export default function SeatingMapV2({
       .join(' ')
   }
 
+  // Etiqueta de una sub-sección de balcón/loge: separa zona + lado + color, sin pegar
+  // palabras ni repetir la zona. `balconyleftcenter` + `blue` → "Balcony Left Center Blue".
+  const zoneSideLabel = (position: string, color: string): string => {
+    const pos = position.toLowerCase()
+    const zone = ['balcony', 'loge'].find((z) => pos.startsWith(z)) || ''
+    const side = pos.slice(zone.length) // 'left' | 'right' | 'leftcenter' | …
+    const zoneLabel = zone ? zone[0].toUpperCase() + zone.slice(1) : ''
+    return [zoneLabel, side && toTitleCaseFromKebab(side), color && toTitleCaseFromKebab(color)]
+      .filter(Boolean)
+      .join(' ')
+  }
+
   useEffect(() => {
     let isMounted = true
     const load = async () => {
@@ -1245,23 +1257,29 @@ export default function SeatingMapV2({
             return
           }
 
-          // Balcón/loge son UN solo grupo por color (`balcony-blue`), no uno por lado.
-          // Así los agrupa el backend; el rangeKey trae `position-color-zone` (p.ej.
-          // `balconyright-blue-balcony`), que abría siempre el mismo lado y con etiqueta
-          // repetida ("Balconyright Blue Balcony"). Normalizar a zona-color.
+          // Balcón/loge: el backend agrupa TODO el balcón en un solo grupo `${zone}-${color}`
+          // (`balcony-blue`); `?group=balconyright-blue` devuelve 0. La zona NO va en def.zone
+          // (queda vacío): va embebida en el prefijo de position (balconyright → balcony). Cada
+          // asiento trae `position` (balconyleft/right/…), así que cargamos el grupo real del API
+          // y filtramos por el lado clickeado. Etiqueta limpia ("Balcony Right Blue"); groupId
+          // queda en el grupo real del API para el refetch de disponibilidad.
           const clickedDef = ranges[key]
-          const canonicalGroup =
-            clickedDef?.zone && clickedDef?.color
-              ? `${clickedDef.zone}-${clickedDef.color}`
-              : groupKey
+          const pos = (clickedDef?.position || '').toLowerCase()
+          const color = String(clickedDef?.color || '')
+          const zone = ['balcony', 'loge'].find((z) => pos.startsWith(z))
+          const apiGroup = zone && color ? `${zone}-${color}` : groupKey
 
-          // Asientos de la sección on-demand (/seats?group=), no de una lista global.
-          const groupSeats = await loadGroupSeats(canonicalGroup)
+          const groupSeats = await loadGroupSeats(apiGroup)
           if (groupSeats.length === 0) return
+
+          const sideSeats = zone
+            ? groupSeats.filter((s) => (s.position || '').toLowerCase() === pos)
+            : groupSeats
+
           onSelectSection({
-            label: toTitleCaseFromKebab(canonicalGroup),
-            seats: groupSeats,
-            groupId: canonicalGroup
+            label: zone ? zoneSideLabel(pos, color) : toTitleCaseFromKebab(apiGroup),
+            seats: sideSeats.length > 0 ? sideSeats : groupSeats,
+            groupId: apiGroup
           })
         }
 

--- a/src/components/v2/sale/SeatingMapV2.tsx
+++ b/src/components/v2/sale/SeatingMapV2.tsx
@@ -323,7 +323,7 @@ export default function SeatingMapV2({
     // Mostrar los colores ya (sin precio); completar el precio en paralelo.
     setLegend([...byColor.keys()].map((color) => ({ color, name: COLOR_LABELS[color] || color })))
     ;(async () => {
-      // Base + asiento representativo (el más barato) por color.
+      // Base mínima por color (el asiento más barato de la sección representativa).
       const reps = await Promise.all(
         [...byColor.entries()].map(async ([color, groupKey]) => {
           try {
@@ -334,39 +334,26 @@ export default function SeatingMapV2({
             return {
               color,
               name: min.price_range || COLOR_LABELS[color] || color,
-              price: min.price ?? undefined,
-              seatId: min.id
+              price: min.price ?? undefined
             }
           } catch {
             return { color, name: COLOR_LABELS[color] || color }
           }
         })
       )
-      // Con fees solo si el evento se configuró INCLUSIVE. /seats no trae el precio con
-      // impuestos → se pide por asiento representativo (1 POST para todos los colores).
+      // Con fees solo si el evento se configuró INCLUSIVE. El fee es por tier de precio
+      // (no por asiento), así que 1 llamada /tickets mapea base → con-fees para todo.
       const ev = await hiEventsService.getEvent(eventId).catch(() => null)
       const inclusive = ev?.settings?.price_display_mode === 'INCLUSIVE'
-      let inclById = new Map<number, number>()
-      if (inclusive) {
-        const ids = reps
-          .map((r) => (r as { seatId?: number }).seatId)
-          .filter((id): id is number => typeof id === 'number')
-        const pricing = await hiEventsService.getTicketsBySeatIds(eventId, ids).catch(() => [])
-        inclById = new Map(
-          pricing
-            .filter((p) => typeof p.price_including_taxes_and_fees === 'number')
-            .map((p) => [p.id, p.price_including_taxes_and_fees as number])
-        )
-      }
+      const tierByBase = inclusive
+        ? await hiEventsService.getPriceTiers(eventId).catch(() => null)
+        : null
       if (!mounted) return
       const rows = reps.map((r) => {
-        const seatId = (r as { seatId?: number }).seatId
         const base = (r as { price?: number }).price
-        return {
-          color: r.color,
-          name: r.name,
-          price: inclusive && seatId != null ? (inclById.get(seatId) ?? base) : base
-        }
+        const withFees =
+          base != null ? (tierByBase?.get(base)?.price_including_taxes_and_fees ?? base) : base
+        return { color: r.color, name: r.name, price: withFees }
       })
       rows.sort((a, b) => (a.price ?? Infinity) - (b.price ?? Infinity))
       setLegend(rows)

--- a/src/components/v2/sale/SeatingMapV2.tsx
+++ b/src/components/v2/sale/SeatingMapV2.tsx
@@ -1258,13 +1258,23 @@ export default function SeatingMapV2({
             return
           }
 
+          // Balcón/loge son UN solo grupo por color (`balcony-blue`), no uno por lado.
+          // Así los agrupa el backend; el rangeKey trae `position-color-zone` (p.ej.
+          // `balconyright-blue-balcony`), que abría siempre el mismo lado y con etiqueta
+          // repetida ("Balconyright Blue Balcony"). Normalizar a zona-color.
+          const clickedDef = ranges[key]
+          const canonicalGroup =
+            clickedDef?.zone && clickedDef?.color
+              ? `${clickedDef.zone}-${clickedDef.color}`
+              : groupKey
+
           // Asientos de la sección on-demand (/seats?group=), no de una lista global.
-          const groupSeats = await loadGroupSeats(groupKey)
+          const groupSeats = await loadGroupSeats(canonicalGroup)
           if (groupSeats.length === 0) return
           onSelectSection({
-            label: toTitleCaseFromKebab(groupKey),
+            label: toTitleCaseFromKebab(canonicalGroup),
             seats: groupSeats,
-            groupId: groupKey
+            groupId: canonicalGroup
           })
         }
 

--- a/src/services/hiEventsService.ts
+++ b/src/services/hiEventsService.ts
@@ -359,13 +359,22 @@ export const hiEventsService = {
     signal?: AbortSignal
   ): Promise<HiSeatPricing[]> {
     if (seatIds.length === 0) return []
-    const body = await request<{ tickets?: HiSeatPricing[] }>(
-      'POST',
-      HIEVENTS_CONFIG.endpoints.ticketsBySeatIds(eventId),
-      { seat_ids: seatIds },
-      signal
+    // El backend rechaza >100 ids por request (secciones grandes como el balcón de
+    // Miami traen 114 → fallaba y caía a precio base sin fees). Trocear en lotes de 100.
+    const CHUNK = 100
+    const chunks: number[][] = []
+    for (let i = 0; i < seatIds.length; i += CHUNK) chunks.push(seatIds.slice(i, i + CHUNK))
+    const results = await Promise.all(
+      chunks.map((ids) =>
+        request<{ tickets?: HiSeatPricing[] }>(
+          'POST',
+          HIEVENTS_CONFIG.endpoints.ticketsBySeatIds(eventId),
+          { seat_ids: ids },
+          signal
+        )
+      )
     )
-    return body.tickets ?? []
+    return results.flatMap((body) => body.tickets ?? [])
   },
 
   async updateOrder(eventId: string | number, shortId: string, payload: unknown): Promise<HiOrder> {

--- a/src/services/hiEventsService.ts
+++ b/src/services/hiEventsService.ts
@@ -15,6 +15,7 @@ import supabase from '../components/supabaseClient'
 import type {
   HiEventPublic,
   HiTicketPublic,
+  HiTicketPrice,
   HiSeatingMap,
   HiSeat,
   HiOrder,
@@ -266,10 +267,7 @@ export const hiEventsService = {
   },
 
   /**
-   * Tickets y precios de un evento. Pide hasta 100 por página (un general puede
-   * tener muchos tipos). No pagina de más a propósito: en un enumerado los asientos
-   * también son "tickets" y traerlos todos acá sería pesado (el detalle solo necesita
-   * una muestra para el "desde $"). Si un general supera 100 tipos, ver deuda técnica.
+   * Tickets y precios de un evento.
    */
   async getTickets(eventId: string | number, signal?: AbortSignal): Promise<HiTicketPublic[]> {
     // ponytail: 1 página de 1000. Eventos enumerados modelan 1 ticket por asiento
@@ -280,6 +278,28 @@ export const hiEventsService = {
       signal
     )
     return body.data
+  },
+
+  /**
+   * Mapa `precio base → tier` del evento (con precio con fees, tax y fee por tier).
+   * El fee es por tier de precio, no por asiento, así que una sola llamada a /tickets
+   * alcanza para poner el precio con fees a TODOS los asientos por su base — sin pedir
+   * asiento por asiento (/tickets/by-seat-ids topa a 100 ids y hacía N requests).
+   * ponytail: se asume que el precio base identifica el tier; si dos zonas comparten
+   * base con fees distintos, habría que indexar por price_range.
+   */
+  async getPriceTiers(
+    eventId: string | number,
+    signal?: AbortSignal
+  ): Promise<Map<number, HiTicketPrice>> {
+    const tickets = await this.getTickets(eventId, signal)
+    const byBase = new Map<number, HiTicketPrice>()
+    for (const t of tickets) {
+      for (const p of t.prices) {
+        if (typeof p.price === 'number' && !byBase.has(p.price)) byBase.set(p.price, p)
+      }
+    }
+    return byBase
   },
 
   // --- Mapa de asientos (C3) ---


### PR DESCRIPTION
## Qué

Cambios del frontend cliente que quedaron fuera del PR #52 (mergeado antes), más el split del balcón por secciones.

### 1. Balcón dividido por lados (mapa Miami)
El balcón es **un solo grupo por color en el backend** (`balcony-blue`, 114 asientos); los grupos por lado (`balconyright-blue`) devuelven 0. Antes, hacer click en cualquier lado del balcón abría todo el balcón bajo una etiqueta única y errónea (`Balconyright Blue Balcony`).

Cada asiento ya trae su `position` (`balconyleft/right/center/…`), así que:
- cargamos el grupo real del API y **filtramos por el lado clickeado**;
- el grupo del API se deriva del prefijo de `position` (`balconyright` → `balcony`);
- etiqueta limpia por lado (`Balcony Right Blue`), sin repetir "Balcony" ni pegar palabras;
- `groupId` queda en el grupo real del API para el refetch de disponibilidad (el poll trae los 114 pero solo se muestran/consultan los del lado).

### 2. Fees por tier de precio, no por asiento
El fee es lineal por **tier de precio base** (`fee = 4 + 0.18·base`), no por asiento. Se reemplaza el request `by-seat-ids` por **un solo `/tickets`** que arma un mapa `base → tier`. `by-seat-ids` se mantiene solo en checkout (resuelve `ticket_id`/`price_id`) y ahora chunkea de a 100 (el backend rechaza >100 ids).

### 3. Precios con fees en leyenda + sticky
- Leyenda del mapa (precios por color): muestra el precio **con fees** cuando el evento es `INCLUSIVE`; corregidos los colores sin precio.
- `/event/:id` sticky "Choose seats From $": precio más bajo **con fees** según config, con **2 decimales**.

## Archivos
- `src/components/v2/sale/SeatingMapV2.tsx` — split balcón + leyenda con fees
- `src/components/v2/sale/SeatPickerV2.tsx` — mapa por tier + chunk de 100 en checkout
- `src/services/hiEventsService.ts` — `getPriceTiers`, `per_page` alto, chunk by-seat-ids
- `src/components/v2/eventDetail/StickyCTA.tsx` — 2 decimales
- `src/pages/v2/EventDetailV2.tsx` — priceFrom con fees según config

## Test
`npx tsc --noEmit` limpio. Verificado contra la API: tiers (40→51.2, 55→68.9, 70→86.6, 85→104.3) coinciden con `by-seat-ids`; balcón filtra 33/15/28/15/23 por lado.