### PR TITLE
fix(wallet): Apple Wallet .pkpass via proxy + richer ticket section

### DIFF
--- a/netlify/functions/proxy-api.js
+++ b/netlify/functions/proxy-api.js
@@ -87,6 +87,26 @@ exports.handler = async (event) => {
       else process.env.NODE_TLS_REJECT_UNAUTHORIZED = prevTlsEnv
     }
 
+    // Respuestas binarias (p.ej. el .pkpass de Apple Wallet) NO se pueden leer como
+    // texto: `response.text()` reinterpreta los bytes no-ASCII como UTF-8 y los
+    // reemplaza por U+FFFD, corrompiendo el ZIP. Base64 + isBase64Encoded para que
+    // Netlify los reenvíe intactos, preservando el Content-Type del upstream.
+    const upstreamType = response.headers.get('content-type') || ''
+    const isTextual = /\b(json|text|xml|javascript|html|x-www-form-urlencoded)\b/i.test(upstreamType)
+
+    if (!isTextual) {
+      const buffer = Buffer.from(await response.arrayBuffer())
+      const passthrough = { ...corsHeaders, 'Content-Type': upstreamType || 'application/octet-stream' }
+      const disposition = response.headers.get('content-disposition')
+      if (disposition) passthrough['Content-Disposition'] = disposition
+      return {
+        statusCode: response.status,
+        headers: passthrough,
+        body: buffer.toString('base64'),
+        isBase64Encoded: true
+      }
+    }
+
     const data = await response.text()
     let responseBody
     try {

--- a/src/pages/v2/TicketReceivedV2.tsx
+++ b/src/pages/v2/TicketReceivedV2.tsx
@@ -59,6 +59,27 @@ const readCartSnapshot = (): CartCheckoutSnapshot | null => {
   }
 }
 
+const SIDE_LABEL: Record<string, string> = {
+  left: 'Left',
+  right: 'Right',
+  center: 'Center',
+  leftcenter: 'Left Center',
+  rightcenter: 'Right Center'
+}
+
+/** Sección para mostrar. En zonas (balcony/loge) el backend guarda `section` como la
+ *  zona sola ("Balcony") y el lado vive en `position` ("balconyright") → "Balcony Right".
+ *  Fuera de esas zonas, deja la sección tal cual. */
+const sectionWithSide = (section?: string | null, position?: string | null): string | undefined => {
+  const sec = section?.trim() || undefined
+  const pos = (position || '').toLowerCase()
+  if (!sec || !pos) return sec
+  const zone = ['balcony', 'loge'].find((z) => pos.startsWith(z))
+  if (!zone) return sec
+  const side = SIDE_LABEL[pos.slice(zone.length)]
+  return side ? `${sec} ${side}` : sec
+}
+
 /** "A15" / "K-7" → { row: "A", seat: "15" }. Los asientos de HiEvents traen el
  *  seatLabel como `${row}${seat_number}`; el flujo Seatchart viejo usaba coords. */
 const parseSeatLabel = (label?: string): { row?: string; seat?: string } => {
@@ -153,7 +174,7 @@ export default function TicketReceivedV2() {
         qrValue: a.public_id || undefined,
         ticketNumber: i + 1,
         seatInfo: {
-          section: a.ticket?.section ?? undefined,
+          section: sectionWithSide(a.ticket?.section, a.ticket?.position),
           row: a.ticket?.row ?? undefined,
           seat: a.ticket?.seat_number ?? undefined
         }


### PR DESCRIPTION
## Problema

En la pantalla del ticket (post-compra):

1. **Apple Wallet falla** con \`The string did not match the expected pattern.\`
2. **La sección solo dice \"Balcony\"** — insuficiente para ubicarse.

## Causa raíz — Apple Wallet

El backend (\`panel.ticketsaver.net/api/apple-pass\`) **sí** devuelve un \`.pkpass\` válido (200, \`application/vnd.apple.pkpass\`, ZIP). Pero el proxy Netlify (\`netlify/functions/proxy-api.js\`) leía **toda** respuesta con \`response.text()\`, que reinterpreta el binario como UTF-8 y reemplaza cada byte no-ASCII por \`U+FFFD\` (0xEF 0xBF 0xBD), corrompiendo el ZIP; además forzaba \`Content-Type: application/json\`. Verificado con curl:

- Directo: 13183 bytes, \`unzip\` OK.
- Vía proxy: 23607 bytes, \`unzip\` → \`start of central directory not found; zipfile corrupt\`.

El cliente tomaba la rama JSON y \`response.json()\` reventaba sobre el binario → ese error.

**Fix:** detectar respuestas no-textuales y devolverlas **base64 + \`isBase64Encoded\`** con el \`Content-Type\` original; JSON queda igual. Roundtrip validado: base64→decode es byte-idéntico al \`.pkpass\` directo y \`unzip\` lo abre.

## Sección más informativa

En zonas (balcony/loge) el backend guarda \`section\` como la zona sola (\"Balcony\") y el lado vive en \`position\` (\"balconyright\"). Se compone **\"Balcony Right\"**. Fuera de esas zonas la sección queda igual.

> Depende de que el attendee (\`AttendeeResourcePublic\`) traiga \`ticket.position\` poblado. Si viniera null, cae con gracia a la sección base (sin regresión).

## Archivos
- \`netlify/functions/proxy-api.js\` — passthrough binario base64
- \`src/pages/v2/TicketReceivedV2.tsx\` — \`sectionWithSide(section, position)\`

## Test
\`npx tsc --noEmit\` limpio. Proxy: verificado contra el backend real que arrayBuffer→base64→decode reconstruye un \`.pkpass\` válido (5 archivos, firma incluida).