### PR TITLE
fix(sale): sección completa del ticket (subZone) + /tickets filtrado por sección

### DIFF
--- a/src/components/v2/sale/SeatPickerV2.tsx
+++ b/src/components/v2/sale/SeatPickerV2.tsx
@@ -94,12 +94,16 @@ export default function SeatPickerV2({
   const [tierByBase, setTierByBase] = useState<Map<number, HiTicketPrice>>(new Map())
   const [pricingReady, setPricingReady] = useState(false)
 
+  // Todos los asientos del grupo comparten position (groupId = position-color),
+  // así que filtramos /tickets a la sección abierta en vez de traer todo el evento.
+  const sectionPosition = section.seats[0]?.position || undefined
+
   useEffect(() => {
     const controller = new AbortController()
     let mounted = true
     setPricingReady(false)
     hiEventsService
-      .getPriceTiers(event.eventId, controller.signal)
+      .getPriceTiers(event.eventId, controller.signal, { position: sectionPosition })
       .then((map) => {
         if (!mounted) return
         setTierByBase(map)
@@ -113,7 +117,7 @@ export default function SeatPickerV2({
       mounted = false
       controller.abort()
     }
-  }, [event.eventId])
+  }, [event.eventId, sectionPosition])
 
   // B1 · Disponibilidad EN VIVO. Refrescamos los asientos de la sección cada ~11s
   // (pausado si la pestaña está oculta). Si un asiento que tenías seleccionado lo

--- a/src/lib/ticketSection.ts
+++ b/src/lib/ticketSection.ts
@@ -1,0 +1,30 @@
+const SIDE_LABEL: Record<string, string> = {
+  left: 'Left',
+  right: 'Right',
+  center: 'Center',
+  leftcenter: 'Left Center',
+  rightcenter: 'Right Center'
+}
+
+/** Sección para mostrar. En zonas (balcony/loge) el backend guarda `section` como la
+ *  zona sola ("Balcony") y el lado vive en el position crudo ("balconyright") → "Balcony Right".
+ *  Fuera de esas zonas, deja la sección tal cual. */
+export const sectionWithSide = (
+  section?: string | null,
+  position?: string | null
+): string | undefined => {
+  const sec = section?.trim() || undefined
+  const pos = (position || '').toLowerCase()
+  if (!sec || !pos) return sec
+  const zone = ['balcony', 'loge'].find((z) => pos.startsWith(z))
+  if (!zone) return sec
+  const side = SIDE_LABEL[pos.slice(zone.length)]
+  return side ? `${sec} ${side}` : sec
+}
+
+/** Sección de un ticket de HiEvents (TicketMinimalResourcePublic). Ojo: la API
+ *  pisa `position` con `seat_number` cuando existe; el position crudo viaja en
+ *  `subZone`, así que se prueba primero. */
+export const ticketSection = (
+  t?: { section?: string | null; position?: string | null; subZone?: string | null } | null
+): string | undefined => sectionWithSide(t?.section, t?.subZone ?? t?.position)

--- a/src/pages/v2/TicketPublicV2.tsx
+++ b/src/pages/v2/TicketPublicV2.tsx
@@ -9,6 +9,7 @@ import { useUIEvents } from '../../hooks/useUIEvents'
 import { hiEventsService } from '../../services/hiEventsService'
 import { hiEventToUIEvent } from '../../services/hiEventsAdapter'
 import { coverHash, coverSeed } from '../../lib/covers/coverHash'
+import { ticketSection } from '../../lib/ticketSection'
 import type { HiAttendee } from '../../types/hievents'
 import type { UIEvent } from '../../types/uiEvent'
 
@@ -94,7 +95,7 @@ export default function TicketPublicV2() {
   }
 
   const seatInfo = {
-    section: attendee.ticket?.section ?? undefined,
+    section: ticketSection(attendee.ticket),
     row: attendee.ticket?.row ?? undefined,
     seat: attendee.ticket?.seat_number ?? undefined
   }

--- a/src/pages/v2/TicketReceivedV2.tsx
+++ b/src/pages/v2/TicketReceivedV2.tsx
@@ -11,6 +11,7 @@ import { useCart } from '../../router/cartContext'
 import { hiEventsService } from '../../services/hiEventsService'
 import type { HiOrder } from '../../types/hievents'
 import { coverHash, coverSeed } from '../../lib/covers/coverHash'
+import { ticketSection } from '../../lib/ticketSection'
 import gradients from '../../styles/effects/gradients.module.css'
 import type { UIEvent } from '../../types/uiEvent'
 
@@ -57,27 +58,6 @@ const readCartSnapshot = (): CartCheckoutSnapshot | null => {
   } catch {
     return null
   }
-}
-
-const SIDE_LABEL: Record<string, string> = {
-  left: 'Left',
-  right: 'Right',
-  center: 'Center',
-  leftcenter: 'Left Center',
-  rightcenter: 'Right Center'
-}
-
-/** Sección para mostrar. En zonas (balcony/loge) el backend guarda `section` como la
- *  zona sola ("Balcony") y el lado vive en `position` ("balconyright") → "Balcony Right".
- *  Fuera de esas zonas, deja la sección tal cual. */
-const sectionWithSide = (section?: string | null, position?: string | null): string | undefined => {
-  const sec = section?.trim() || undefined
-  const pos = (position || '').toLowerCase()
-  if (!sec || !pos) return sec
-  const zone = ['balcony', 'loge'].find((z) => pos.startsWith(z))
-  if (!zone) return sec
-  const side = SIDE_LABEL[pos.slice(zone.length)]
-  return side ? `${sec} ${side}` : sec
 }
 
 /** "A15" / "K-7" → { row: "A", seat: "15" }. Los asientos de HiEvents traen el
@@ -174,7 +154,7 @@ export default function TicketReceivedV2() {
         qrValue: a.public_id || undefined,
         ticketNumber: i + 1,
         seatInfo: {
-          section: sectionWithSide(a.ticket?.section, a.ticket?.position),
+          section: ticketSection(a.ticket),
           row: a.ticket?.row ?? undefined,
           seat: a.ticket?.seat_number ?? undefined
         }

--- a/src/services/hiEventsService.ts
+++ b/src/services/hiEventsService.ts
@@ -267,14 +267,19 @@ export const hiEventsService = {
   },
 
   /**
-   * Tickets y precios de un evento.
+   * Tickets y precios de un evento. `filter.position` (match exacto) limita a los
+   * asientos de una sección del mapa — el backend ya lo soporta.
    */
-  async getTickets(eventId: string | number, signal?: AbortSignal): Promise<HiTicketPublic[]> {
+  async getTickets(
+    eventId: string | number,
+    signal?: AbortSignal,
+    filter?: { position?: string; section?: string }
+  ): Promise<HiTicketPublic[]> {
     // ponytail: 1 página de 1000. Eventos enumerados modelan 1 ticket por asiento
     // (~866 en Miami); con per_page=100 el "desde $X" salía del mínimo de la 1ª página,
     // no el global. Si algún evento supera 1000 tickets, paginar acá.
     const body = await getJson<HiPaginated<HiTicketPublic>>(
-      `${HIEVENTS_CONFIG.endpoints.eventTickets(eventId)}${toQuery({ per_page: 1000 })}`,
+      `${HIEVENTS_CONFIG.endpoints.eventTickets(eventId)}${toQuery({ per_page: 1000, ...filter })}`,
       signal
     )
     return body.data
@@ -290,9 +295,10 @@ export const hiEventsService = {
    */
   async getPriceTiers(
     eventId: string | number,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    filter?: { position?: string; section?: string }
   ): Promise<Map<number, HiTicketPrice>> {
-    const tickets = await this.getTickets(eventId, signal)
+    const tickets = await this.getTickets(eventId, signal, filter)
     const byBase = new Map<number, HiTicketPrice>()
     for (const t of tickets) {
       for (const p of t.prices) {

--- a/src/types/hievents.ts
+++ b/src/types/hievents.ts
@@ -199,6 +199,8 @@ export interface HiAttendeeTicket {
   row?: string | null
   seat_number?: string | null
   position?: string | null
+  /** Position crudo del asiento ("balconyright"); `position` viene pisado por seat_number. */
+  subZone?: string | null
   price_range?: string | null
 }
 


### PR DESCRIPTION
## Qué arregla

**1. Sección "Balcony" sola en las vistas de ticket (re-reportado)**
El fix del PR #54 nunca funcionó: la API pública pisa `position` con `seat_number` cuando existe, así que al cliente le llegaba `"39"` en vez de `"balconyright"`. El position crudo viaja en `subZone`. Nuevo helper compartido `src/lib/ticketSection.ts` que lo usa, aplicado a:
- `TicketPublicV2` (la vista del link del mail — no tenía el fix)
- `TicketReceivedV2` (post-compra)

**2. `/public/events/{id}/tickets?per_page=1000` en cada apertura de sección**
El seat picker traía TODOS los tickets del evento (~1000) al abrir cualquier sección. Todos los asientos de un grupo comparten `position` y el backend ya soporta `?position=` en ese endpoint, así que `getPriceTiers` ahora filtra a la sección abierta.

## Verificación
- `tsc --noEmit` sin errores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)