### PR TITLE
fix(tickets): una card por asiento en My Tickets + sección con zona numerada

### DIFF
--- a/src/components/v2/ticket/TicketCard.tsx
+++ b/src/components/v2/ticket/TicketCard.tsx
@@ -22,6 +22,8 @@ interface TicketCardProps {
   qrValue?: string
   /** Hace toda la card un Link al detalle (variant list). */
   href?: string
+  /** Chip con el asiento en el variant 'list' ("Zona 205 · Fila A · Asiento 1"). */
+  seatLabel?: string
   /** Cuando true, hace el filter saturate(.6) opacity(.7) para "past events". */
   past?: boolean
   className?: string
@@ -42,6 +44,7 @@ export default function TicketCard({
   ticketNumber,
   qrValue,
   href,
+  seatLabel,
   past,
   className
 }: TicketCardProps) {
@@ -57,7 +60,7 @@ export default function TicketCard({
     )
   }
 
-  const card = <ListTicket event={event} past={past} className={className} />
+  const card = <ListTicket event={event} past={past} seatLabel={seatLabel} className={className} />
   if (href) {
     return (
       <Link to={href} className='block focus-visible:outline-none'>
@@ -244,10 +247,12 @@ const FakeQR = ({ seed }: { seed: string }) => {
 const ListTicket = ({
   event,
   past,
+  seatLabel,
   className
 }: {
   event: UIEvent
   past?: boolean
+  seatLabel?: string
   className?: string
 }) => {
   const palette = getCoverPalette(event.cover)
@@ -306,8 +311,9 @@ const ListTicket = ({
             {event.venueName}
             {event.city && ` · ${event.city}`}
           </div>
-          <div className='mt-auto flex items-center gap-1.5'>
+          <div className='mt-auto flex items-center gap-1.5 min-w-0'>
             <Tag>{event.time || 'TBA'}</Tag>
+            {seatLabel && <Tag>{seatLabel}</Tag>}
           </div>
         </div>
       </div>

--- a/src/components/v2/ticket/TicketGrid.tsx
+++ b/src/components/v2/ticket/TicketGrid.tsx
@@ -3,15 +3,22 @@ import { GlassCard } from '../../ui'
 import { cn } from '../../../types/ui'
 import type { UIEvent } from '../../../types/uiEvent'
 
+export interface TicketGridItem {
+  key: string
+  event: UIEvent
+  href?: string
+  /** "Zona 205 · Fila A · Asiento 1" — distingue cards del mismo evento. */
+  seatLabel?: string
+}
+
 interface TicketGridProps {
-  events: UIEvent[]
+  /** Una card por TICKET (asiento), no por evento. */
+  items: TicketGridItem[]
   /** Marca todas como pasadas (visual saturado). */
   past?: boolean
-  /** Mensaje cuando no hay eventos. */
+  /** Mensaje cuando no hay tickets. */
   emptyMessage?: string
   className?: string
-  /** Builder del href de cada ticket. */
-  hrefFor?: (event: UIEvent) => string | undefined
 }
 
 /**
@@ -19,13 +26,12 @@ interface TicketGridProps {
  * Para upcoming y past.
  */
 export default function TicketGrid({
-  events,
+  items,
   past,
   emptyMessage = "You don't have any events here yet.",
-  className,
-  hrefFor
+  className
 }: TicketGridProps) {
-  if (events.length === 0) {
+  if (items.length === 0) {
     return (
       <GlassCard depth='sm' radius='lg' className='p-8 text-center'>
         <div className='font-display text-base font-semibold text-white'>Nothing here yet</div>
@@ -35,13 +41,14 @@ export default function TicketGrid({
   }
   return (
     <div className={cn('grid gap-3 sm:grid-cols-2', className)}>
-      {events.map((event) => (
+      {items.map((item) => (
         <TicketCard
-          key={event.id}
-          event={event}
+          key={item.key}
+          event={item.event}
           variant='list'
           past={past}
-          href={hrefFor?.(event)}
+          href={item.href}
+          seatLabel={item.seatLabel}
         />
       ))}
     </div>

--- a/src/lib/ticketSection.ts
+++ b/src/lib/ticketSection.ts
@@ -6,20 +6,26 @@ const SIDE_LABEL: Record<string, string> = {
   rightcenter: 'Right Center'
 }
 
-/** Sección para mostrar. En zonas (balcony/loge) el backend guarda `section` como la
- *  zona sola ("Balcony") y el lado vive en el position crudo ("balconyright") → "Balcony Right".
- *  Fuera de esas zonas, deja la sección tal cual. */
+/** Sección para mostrar. El backend guarda `section` como la zona sola ("Balcony")
+ *  y el detalle vive en el position crudo, con dos formatos según el venue:
+ *  - Miami: sección + lado concatenados ("balconyright") → "Balcony Right".
+ *  - San Jose: número de zona aparte ("205") → "Balcony 205".
+ *  Si position no agrega nada (igual a la sección), queda la sección sola. */
 export const sectionWithSide = (
   section?: string | null,
   position?: string | null
 ): string | undefined => {
   const sec = section?.trim() || undefined
-  const pos = (position || '').toLowerCase()
-  if (!sec || !pos) return sec
-  const zone = ['balcony', 'loge'].find((z) => pos.startsWith(z))
-  if (!zone) return sec
-  const side = SIDE_LABEL[pos.slice(zone.length)]
-  return side ? `${sec} ${side}` : sec
+  const posRaw = (position || '').trim()
+  const pos = posRaw.toLowerCase()
+  if (!posRaw) return sec
+  if (!sec) return posRaw
+  const secKey = sec.toLowerCase().replace(/\s+/g, '')
+  if (pos.startsWith(secKey)) {
+    const side = SIDE_LABEL[pos.slice(secKey.length)]
+    return side ? `${sec} ${side}` : sec
+  }
+  return `${sec} ${posRaw}`
 }
 
 /** Sección de un ticket de HiEvents (TicketMinimalResourcePublic). Ojo: la API

--- a/src/pages/v2/dashboardTabs/PastV2.tsx
+++ b/src/pages/v2/dashboardTabs/PastV2.tsx
@@ -3,7 +3,7 @@ import { useOutletContext } from 'react-router-dom'
 import TicketGrid from '../../../components/v2/ticket/TicketGrid'
 import { userTicketsEventToUIEvent } from '../../../services/hiEventsAdapter'
 import type { MyTicketsContext } from '../MyTicketsV2'
-import { ticketHref, TicketListSkeleton } from './_shared'
+import { toGridItems, TicketListSkeleton } from './_shared'
 
 /**
  * Tickets pasados del usuario (eventos cuya fecha ya pasó), reales de HiEvents.
@@ -12,17 +12,9 @@ import { ticketHref, TicketListSkeleton } from './_shared'
 export default function PastV2() {
   const { past, loading } = useOutletContext<MyTicketsContext>()
 
-  const events = useMemo(() => past.map(userTicketsEventToUIEvent), [past])
-  const hrefBySlug = useMemo(() => new Map(past.map((e) => [e.eventId, ticketHref(e)])), [past])
+  const items = useMemo(() => toGridItems(past, userTicketsEventToUIEvent), [past])
 
   if (loading) return <TicketListSkeleton />
 
-  return (
-    <TicketGrid
-      events={events}
-      past
-      hrefFor={(e) => hrefBySlug.get(e.id)}
-      emptyMessage="You don't have past events yet."
-    />
-  )
+  return <TicketGrid items={items} past emptyMessage="You don't have past events yet." />
 }

--- a/src/pages/v2/dashboardTabs/UpcomingV2.tsx
+++ b/src/pages/v2/dashboardTabs/UpcomingV2.tsx
@@ -4,11 +4,11 @@ import TicketGrid from '../../../components/v2/ticket/TicketGrid'
 import { userTicketsEventToUIEvent } from '../../../services/hiEventsAdapter'
 import { hiEventsService } from '../../../services/hiEventsService'
 import type { MyTicketsContext } from '../MyTicketsV2'
-import { ticketHref, TicketListSkeleton } from './_shared'
+import { toGridItems, TicketListSkeleton } from './_shared'
 
 /**
  * Tickets próximos del usuario (eventos con fecha futura), reales de HiEvents.
- * Una card por evento; el link lleva a su ticketera pública (QR real).
+ * Una card por ASIENTO; cada link lleva a la ticketera pública de ese QR.
  *
  * Con `?event=<id>&order=<shortId>` (link de los mails de compra) filtramos a
  * los tickets de esa orden: resolvemos la orden y cruzamos sus `public_id` con
@@ -51,18 +51,13 @@ export default function UpcomingV2() {
       .filter((e) => e.tickets.length > 0)
   }, [upcoming, orderTicketIds])
 
-  const events = useMemo(() => filtered.map(userTicketsEventToUIEvent), [filtered])
-  const hrefBySlug = useMemo(
-    () => new Map(filtered.map((e) => [e.eventId, ticketHref(e)])),
-    [filtered]
-  )
+  const items = useMemo(() => toGridItems(filtered, userTicketsEventToUIEvent), [filtered])
 
   if (loading || orderLoading) return <TicketListSkeleton />
 
   return (
     <TicketGrid
-      events={events}
-      hrefFor={(e) => hrefBySlug.get(e.id)}
+      items={items}
       emptyMessage={
         orderTicketIds
           ? 'No encontramos los tickets de esta compra.'

--- a/src/pages/v2/dashboardTabs/_shared.tsx
+++ b/src/pages/v2/dashboardTabs/_shared.tsx
@@ -1,18 +1,44 @@
 import type { HiUserTicketsEvent } from '../../../types/hievents'
+import type { UIEvent } from '../../../types/uiEvent'
 
-/**
- * Link a la ticketera pública (QR real) de un evento. Toma el primer ticket
- * ACTIVE (o el primero que haya) → `/ticket/:eventIdNumber/:publicId`.
- *
- * Nota (deuda): un evento puede tener varios tickets (varios asientos), cada
- * uno con su propio QR. Por ahora la card del evento linkea al primero; mostrar
- * todos los QR de una compra es una mejora futura.
- */
-export const ticketHref = (e: HiUserTicketsEvent): string | undefined => {
-  const t = e.tickets?.find((x) => x.status === 'ACTIVE') ?? e.tickets?.[0]
-  if (!t) return undefined
-  return `/ticket/${e.eventIdNumber}/${encodeURIComponent(t.ticketId)}`
+/** Una card por ASIENTO (antes era una por evento y solo linkeaba al primer
+ *  ticket — un comprador con 2 asientos veía "un solo boleto"). */
+export interface TicketEntry {
+  key: string
+  href?: string
+  seatLabel?: string
 }
+
+/** Entradas por ticket de un evento del usuario. Excluye CANCELLED. En el
+ *  endpoint de my-tickets `zone` es el position crudo y `section` es la FILA
+ *  (mapeo histórico del backend). */
+export const ticketEntries = (e: HiUserTicketsEvent): TicketEntry[] => {
+  const active = (e.tickets ?? []).filter((t) => t.status !== 'CANCELLED')
+  return active.map((t, i) => {
+    const seat = [
+      t.zone && `Zona ${t.zone}`,
+      t.section && `Fila ${t.section}`,
+      t.seatNumber && `Asiento ${t.seatNumber}`
+    ]
+      .filter(Boolean)
+      .join(' · ')
+    return {
+      key: t.ticketId,
+      href: `/ticket/${e.eventIdNumber}/${encodeURIComponent(t.ticketId)}`,
+      seatLabel: seat || (active.length > 1 ? `Ticket ${i + 1} de ${active.length}` : undefined)
+    }
+  })
+}
+
+/** Aplana eventos del usuario a items del grid: una card por asiento. */
+export const toGridItems = (
+  events: HiUserTicketsEvent[],
+  toUIEvent: (e: HiUserTicketsEvent) => UIEvent
+): Array<TicketEntry & { event: UIEvent }> =>
+  events.flatMap((e) => {
+    const ui = toUIEvent(e)
+    return ticketEntries(e).map((t) => ({ ...t, event: ui }))
+  })
 
 /** Skeleton de la lista de tickets mientras carga el endpoint. */
 export const TicketListSkeleton = () => (


### PR DESCRIPTION
## Reporte de compradora real (daisyylopez4@…, orden con 2 asientos de Las Alucines)

**1. "Solo me aparece 1 de 2 boletos"**
El backend devuelve ambos tickets (verificado contra prod: A1 y A2, ACTIVE). El bug era del front: My Tickets colapsaba los N asientos de un evento en **una** card que linkeaba solo al primer QR (deuda documentada en `ticketHref`: "mostrar todos los QR es una mejora futura"). Ahora: **una card por asiento**, cada una con chip "Zona 205 · Fila A · Asiento 1" y link a su propio QR. Tickets CANCELLED se excluyen; para eventos sin asientos numerados con varios tickets, el chip cae a "Ticket N de M".

**2. "El boleto no dice la zona del balcón"**
En San Jose el `position` crudo es la **zona numerada aparte** (`"205"`), no el formato Miami sección+lado concatenados (`"balconyright"`). `sectionWithSide` ahora compone ambos: → **"Balcony 205"** / "Balcony Right", y cae al position crudo si no hay sección. Aplica a la vista del ticket (TicketPublicV2) y post-compra (TicketReceivedV2) vía el helper compartido.

Solo cambios de front — no requiere deploy del panel. Independiente del PR #56.

## Verificación
- `tsc --noEmit` sin errores.
- Data real verificada: `GET /public/events/24/attendees/A-C1O5IU2` → section "Balcony", subZone "205" → "Balcony 205".

🤖 Generated with [Claude Code](https://claude.com/claude-code)