### PR TITLE
fix(auth): redirectTo explícito en el mail de recuperación de contraseña

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -181,7 +181,13 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   )
 
   const forgotPassword = useCallback(async (email: string) => {
-    const { error } = await requireSupabase().auth.resetPasswordForEmail(email)
+    // redirectTo explicito: sin el, el link del mail aterriza en el "Site URL"
+    // del proyecto Supabase (config externa al repo) y el usuario queda en la
+    // home con la sesion de recovery, sin la pantalla para elegir password.
+    // Requiere que la URL este en Authentication > URL Configuration > Redirect URLs.
+    const { error } = await requireSupabase().auth.resetPasswordForEmail(email, {
+      redirectTo: `${window.location.origin}/reset-password`
+    })
     if (error) throw error
   }, [])
 


### PR DESCRIPTION
Salió investigando por qué una compradora migrada (`andreamadrigal@outlook.com`) reporta que "no la deja entrar" sin dejar rastro en los logs de Supabase.

## El problema

`resetPasswordForEmail(email)` se llamaba **sin `redirectTo`**. Sin ese parámetro, el link del mail de recuperación aterriza en el **Site URL** del proyecto Supabase — configuración que vive fuera del repo y no se ve en code review.

Resultado: quien pide "olvidé mi contraseña" queda en la home con la sesión de recovery abierta, pero **sin la pantalla para elegir contraseña nueva**. Hoy solo llega a ella de rebote, si es un usuario migrado (el gate lo redirige por `must_change_password`). Para cualquier otro, el flujo termina sin cambiar nada.

Ahora apunta explícito a `/reset-password` del origin actual.

## ⚠️ Requiere un cambio de config (si no, no cambia nada)

Agregar en Supabase → Authentication → URL Configuration → **Redirect URLs**:

```
https://www.ticketsaver.net/reset-password
https://ticketsaver.net/reset-password
```

Si la URL no está en esa allowlist, Supabase ignora el `redirectTo` y cae al Site URL — o sea, exactamente el comportamiento actual. El cambio es seguro de mergear igual: en el peor caso no empeora nada.

## Verificación
- `tsc --noEmit` sin errores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)