### PR TITLE
fix(multifecha): resolver el evento por eventId, no por slug

### DIFF
--- a/src/components/v2/checkout/CheckoutV2.tsx
+++ b/src/components/v2/checkout/CheckoutV2.tsx
@@ -31,10 +31,26 @@ export default function CheckoutV2() {
   const navigate = useNavigate()
   const { user } = useAuth()
   const { items: cart, eventLabel, pricing } = useCart()
-  const { byLabel } = useUIEvents()
+  const { byLabel, byId } = useUIEvents()
   const timer = useSessionTimer(eventLabel ?? undefined, 10)
 
-  const event = byLabel(eventLabel ?? undefined)
+  // MULTIFECHA: el slug se repite entre horarios (mismo título/venue, otra hora), así
+  // que `byLabel` devuelve siempre la fecha más temprana. El seat-picker ya dejó el
+  // eventId numérico correcto en `cart_checkout` → ese manda. Sin esto, una compra de
+  // las 18:30 reservaba en el evento correcto pero pagaba contra el de las 16:00:
+  // updateOrder/createStripeCheckoutSession fallaban y la orden moría en RESERVED.
+  const snapshotEventId = useMemo(() => {
+    try {
+      const raw = localStorage.getItem('cart_checkout')
+      if (!raw) return undefined
+      const snap = JSON.parse(raw) as { eventInfo?: { eventId?: string } }
+      return snap.eventInfo?.eventId
+    } catch {
+      return undefined
+    }
+  }, [])
+
+  const event = byId(snapshotEventId) ?? byLabel(eventLabel ?? undefined)
 
   const eventInfo = useMemo(
     () =>
@@ -73,7 +89,16 @@ export default function CheckoutV2() {
   // webhook / ReturnPage legacy lo necesita.
   useEffect(() => {
     if (cart.length === 0 || !eventInfo) return
-    localStorage.setItem('cart_checkout', JSON.stringify({ cart, eventInfo, customer }))
+    // MERGE, no overwrite: el seat-picker dejó acá orderShortId/priceIds/sessionIdentifier
+    // y CheckoutStripe los necesita. Pisarlos hacía que un refresh en /checkout creara una
+    // orden nueva (segundo hold sobre los mismos asientos).
+    let prev: Record<string, unknown> = {}
+    try {
+      prev = JSON.parse(localStorage.getItem('cart_checkout') ?? '{}') as Record<string, unknown>
+    } catch {
+      prev = {}
+    }
+    localStorage.setItem('cart_checkout', JSON.stringify({ ...prev, cart, eventInfo, customer }))
   }, [cart, eventInfo, customer])
 
   if (cart.length === 0 || !event || !eventInfo) {

--- a/src/components/v2/eventDetail/StickyCTA.tsx
+++ b/src/components/v2/eventDetail/StickyCTA.tsx
@@ -71,7 +71,8 @@ export const getCtaState = (
 
   const priceLabel = priceFrom !== null ? `From $${priceFrom.toFixed(2)}` : ''
 
-  const queueHref = `/queue/${encodeURIComponent(event.id)}`
+  // eventId numérico (único por fecha): el slug se repite en multifecha.
+  const queueHref = `/queue/${encodeURIComponent(event.eventId)}`
 
   const targetHref =
     overrideHref ??

--- a/src/components/v2/sale/SeatPickerV2.tsx
+++ b/src/components/v2/sale/SeatPickerV2.tsx
@@ -418,7 +418,7 @@ export default function SeatPickerV2({
         e.status === 403 &&
         (e.body as { error_code?: string } | null)?.error_code?.startsWith('QUEUE_TOKEN')
       if (queueRequired) {
-        navigate(`/queue/${event.id}`)
+        navigate(`/queue/${event.eventId}`)
         return
       }
       const conflict = e instanceof HiEventsApiError && (e.status === 409 || e.status === 422)

--- a/src/pages/v2/QueueV2.tsx
+++ b/src/pages/v2/QueueV2.tsx
@@ -24,7 +24,9 @@ const buildSaleHref = (event: UIEvent): string => {
   const safe = (s: string | undefined | null) => encodeURIComponent(s ?? '')
   const cityForRoute = event.city || event.venueLabel
   const deleteParam = event.raw.event_deleted_at ?? 'null'
-  return `/sale/${safe(event.title)}/${safe(event.venueLabel)}/${safe(cityForRoute)}/${safe(event.raw.event_date)}/${safe(event.id)}/${safe(deleteParam)}`
+  // ?eid = eventId numérico. En multifecha el slug se repite entre horarios, así que sin
+  // esto el usuario salía de la cola de las 18:30 al mapa de las 16:00.
+  return `/sale/${safe(event.title)}/${safe(event.venueLabel)}/${safe(cityForRoute)}/${safe(event.raw.event_date)}/${safe(event.id)}/${safe(deleteParam)}?eid=${safe(event.eventId)}`
 }
 
 /**
@@ -37,8 +39,9 @@ const buildSaleHref = (event: UIEvent): string => {
 export default function QueueV2() {
   const { label } = useParams<{ label: string }>()
   const navigate = useNavigate()
-  const { loading: eventsLoading, byLabel } = useUIEvents()
-  const event = byLabel(label)
+  const { loading: eventsLoading, byLabel, byId } = useUIEvents()
+  // :label acepta el eventId numérico (multifecha) o el slug (compat con links viejos).
+  const event = byId(label) ?? byLabel(label)
   const eventId = event ? Number(event.eventId) : undefined
 
   const {


### PR DESCRIPTION
## Problema

En multifecha (mismo título y venue, distinto horario) los eventos comparten slug. `byLabel()` de `useUIEvents` hace `all.find(e => e.id === label)` sobre una lista ordenada por fecha ascendente, así que **siempre devuelve el horario más temprano**.

El seat-picker ya usaba el `eventId` numérico vía `?eid`, pero el checkout y la cola resolvían por slug. Resultado: una compra del horario tardío reservaba en el evento correcto y después pagaba contra el evento equivocado. `updateOrder(eventIdIncorrecto, orderShortId)` y `createStripeCheckoutSession` fallaban, y la orden moría en `RESERVED` reteniendo los asientos 10 minutos.

## Evidencia en producción

Plim Plim Miami — evento 25 (18:30) y evento 32 (16:00), mismo slug `plim-plim-en-vivo-miami-fl`:

| event | status | payment_status | órdenes |
|---|---|---|---|
| 25 | RESERVED | *(vacío)* | 72 |
| 32 | COMPLETED | PAYMENT_RECEIVED | 29 |
| 32 | RESERVED | AWAITING_PAYMENT | 14 |

Ninguna orden del evento 25 pasó de `RESERVED` a `AWAITING_PAYMENT` — nunca llegaron a Stripe. Cero ventas y cero attendees en el 18:30.

Efecto secundario visible: el mapa del 18:30 mostraba asientos bloqueados sin attendees. Eran sus propios holds. Cada intento fallido retiene 10 min y entraban intentos nuevos todo el tiempo, así que siempre había ~15-20 asientos en rojo. Verificado que en la DB no hay ningún cruce real: `tickets`, `order_items` y `attendees` están 100% separados por `event_id`.

## Cambios

- **`CheckoutV2`** — resuelve el evento por el `eventId` que el seat-picker deja en el snapshot `cart_checkout`; cae al slug solo por compatibilidad.
- **`CheckoutV2`** — el snapshot ahora hace *merge* en vez de pisar. Antes borraba `orderShortId`/`priceIds`/`sessionIdentifier`, así que un refresh en `/checkout` hacía que `CheckoutStripe` creara una **segunda** orden sobre los mismos asientos.
- **`QueueV2`** — resuelve por `eventId` (acepta slug por compat con links viejos) y su `buildSaleHref` de salida ahora lleva `?eid`. Antes te sacaba de la cola de un horario al mapa de otro.
- **`StickyCTA`** y **`SeatPickerV2`** — navegan a `/queue/:eventId` en vez de `/queue/:slug`.

## Verificación

- `npx tsc --noEmit` sin errores.
- Manual, con un evento multifecha:
  1. Detalle → elegir el horario **tardío** → Choose seats → confirmar que la URL lleva `?eid=<id del horario tardío>`.
  2. Reservar asientos → en `/checkout`, la llamada a Stripe debe ir contra ese mismo id.
  3. Refrescar `/checkout` → no debe crearse una segunda orden (mismo `orderShortId`).
  4. Completar el pago → la venta y los attendees caen en el horario tardío.
  5. Repetir con el horario temprano (regresión).

## Fuera de alcance

Queda pendiente, en el backend/infra:

- Las 72 órdenes muertas del evento 25 siguen en `RESERVED`. No bloquean asientos (la query de disponibilidad filtra `reserved_until > NOW()`), pero ensucian los reportes. El comando `orders:cancel-expired` está agendado `everyMinute` en `routes/console.php` y **no corre**: no hay cron en el nodo.
- El evento 32 tiene 45 asientos con `quantity_sold` por debajo de los attendees ACTIVE (86 vs 133) y 7 butacas con dos dueños activos. Mismo bug de contador del evento 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
