### PR TITLE
feat(tickets): mostrar hora y año de la función en el ticket

### DIFF
--- a/src/components/v2/ticket/TicketCard.tsx
+++ b/src/components/v2/ticket/TicketCard.tsx
@@ -134,7 +134,7 @@ const HeroTicket = ({
       {/* Big date */}
       <div className='relative px-5 pt-8 pb-5 text-center text-white'>
         <div className='text-[9.5px] font-display font-bold uppercase tracking-[0.2em] opacity-70'>
-          {event.day} · {event.month}
+          {event.day} · {event.month} {event.year}
         </div>
         <div className='font-display font-bold leading-[0.9] tracking-[-0.04em] text-[88px] sm:text-[96px] mt-1'>
           {String(event.date).padStart(2, '0')}
@@ -311,8 +311,13 @@ const ListTicket = ({
             {event.venueName}
             {event.city && ` · ${event.city}`}
           </div>
+          {/* Hora + año: el strip de la izquierda ya da día/mes. Dos funciones
+              del mismo show caen el mismo día y solo la hora las distingue,
+              así que va como texto legible y no como tag chico en mayúsculas. */}
+          <div className='text-[11px] font-semibold text-white/85 truncate'>
+            {event.time || 'TBA'} · {event.year}
+          </div>
           <div className='mt-auto flex items-center gap-1.5 min-w-0'>
-            <Tag>{event.time || 'TBA'}</Tag>
             {seatLabel && <Tag>{seatLabel}</Tag>}
           </div>
         </div>


### PR DESCRIPTION
## Problema

Dos funciones del mismo show son eventos distintos con el mismo título, venue y día. Ejemplo real (Plim Plim Miami, 25/10/2026):

| id | start_date | tz |
|----|-----------|-----|
| 32 | 4:00 PM | America/New_York |
| 25 | 6:30 PM | America/New_York |

En **My Tickets** las dos cards se ven idénticas: solo las distinguía un tag chico en mayúsculas al lado del asiento, fácil de pasar por alto.

## Cambio

`TicketCard.tsx`:

- **Card de lista** (Upcoming / Past / Resales): la hora pasa a línea propia bajo el venue, en negrita y con el año. El tag queda solo para el asiento.
- **Ticket individual** (hero, `/ticket/:eventId/:ticketId`): la línea `SAT · OCT` ahora incluye el año.

El strip lateral ya muestra día/número/mes, así que no se duplica la fecha.

```
Plim Plim - En Vivo! Miami, Fl
Miami Beach Bandshell · Miami
4:00 PM · 2026
[Zona 205 · Fila A · Asiento 1]
```

La hora sale de `start_date` + `timezone` del evento (`toDateParts`), que ya venían en `/customer-auth/my-tickets`. Sin cambios de backend.

## Verificación

- `tsc --noEmit`: sin errores
- `vite build`: OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)