### PR TITLE
fix(pwa): desregistrar el service worker viejo que sirve el front anterior

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,34 @@
+// Kill-switch del Service Worker viejo.
+//
+// El sitio anterior se construia con vite-plugin-pwa (workbox, registerType
+// 'autoUpdate', globPatterns con **/*.html): precacheaba index.html y todos los
+// assets. El rediseno quito el plugin, asi que /sw.js dejo de existir en el
+// build y el _redirects SPA lo respondia como index.html (text/html). El
+// navegador rechaza esa actualizacion ("unsupported MIME type") y NO desregistra
+// el worker viejo: sigue sirviendo el index.html precacheado, o sea el front
+// anterior, para siempre. Por eso algunos usuarios ven el sitio viejo.
+//
+// Este archivo lo reemplaza por un worker que se autodestruye: borra las caches,
+// se desregistra y recarga las pestanas abiertas.
+//
+// NO BORRAR. Un usuario que no vuelve en meses todavia tiene el SW viejo
+// registrado y necesita encontrar este archivo cuando vuelva.
+// ponytail: sin fetch handler a proposito, asi toda navegacion va a la red.
+
+self.addEventListener('install', () => {
+  self.skipWaiting()
+})
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    (async () => {
+      const keys = await caches.keys()
+      await Promise.all(keys.map((key) => caches.delete(key)))
+
+      await self.registration.unregister()
+
+      const clients = await self.clients.matchAll({ type: 'window' })
+      clients.forEach((client) => client.navigate(client.url))
+    })()
+  )
+})


### PR DESCRIPTION
## Problema

Usuarios que entran a ticketsaver.net siguen viendo el **front anterior** al rediseño. Un hard refresh no lo arregla.

## Causa

El sitio previo se construía con `vite-plugin-pwa` (workbox, `registerType: 'autoUpdate'`, `globPatterns: ['**/*.{js,css,html,ico,png,svg}']`) → **precacheaba `index.html`**. El rediseño (`11f5d31`) quitó el plugin de `vite.config.ts`, así que `/sw.js` dejó de existir en el build y el `_redirects` SPA lo responde como `index.html`.

Verificado en producción:

```
GET https://ticketsaver.net/sw.js
HTTP/2 200
content-type: text/html; charset=UTF-8    ← index.html, no un script
```

El navegador chequea `/sw.js` para actualizar el worker, recibe HTML, rechaza la actualización (*"The script has an unsupported MIME type ('text/html')"*) y **no desregistra el worker viejo**. Ese worker sigue sirviendo el `index.html` precacheado — el front anterior — indefinidamente, e intercepta la navegación, por eso el hard refresh tampoco sirve.

## Solución

`public/sw.js` como archivo estático real (los estáticos ganan sobre el redirect SPA), con un worker que se autodestruye: borra todas las caches, se desregistra y recarga las pestañas abiertas. Sin `fetch` handler, así toda navegación va a la red.

## Verificación post-deploy

```bash
curl -sI https://ticketsaver.net/sw.js | grep -i content-type
# debe decir: content-type: application/javascript
```

Si sigue en `text/html`, el archivo no llegó al `dist`.

## Nota

**No borrar `public/sw.js`.** Un usuario que vuelve dentro de meses todavía tiene el SW viejo registrado y necesita encontrar este archivo cuando vuelva.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
