### PR TITLE
feat(cart): botón para eliminar un ticket del resumen de compra

### DIFF
--- a/src/components/v2/sale/CartSummaryPanel.tsx
+++ b/src/components/v2/sale/CartSummaryPanel.tsx
@@ -55,6 +55,54 @@ export interface CartSummaryItem {
   tax?: number
 }
 
+/** Fila del listado, compartida por el sidebar y el bottom sheet. */
+const SummaryItemRow = ({
+  item,
+  onRemoveItem
+}: {
+  item: CartSummaryItem
+  onRemoveItem?: (id: string) => void
+}) => {
+  const b = breakdownPerItem(item)
+  return (
+    <li className='rounded-glass-sm bg-white/[0.04] border border-white/[0.08] px-3 py-2.5'>
+      <div className='flex items-start justify-between gap-3'>
+        <div className='min-w-0 flex-1'>
+          <div className='font-display text-[12.5px] font-semibold text-white truncate'>
+            {item.label}
+          </div>
+          {item.sublabel && (
+            <div className='text-[10.5px] text-white/55 mt-0.5 truncate'>{item.sublabel}</div>
+          )}
+        </div>
+        <div className='flex items-start gap-2 shrink-0'>
+          <span className='font-display text-[13px] font-bold text-white tabular-nums'>
+            ${b.total.toFixed(2)}
+          </span>
+          {onRemoveItem && (
+            <button
+              type='button'
+              aria-label={`Remove ${item.label}`}
+              onClick={() => onRemoveItem(item.id)}
+              className='grid h-6 w-6 place-items-center rounded-pill bg-white/[0.06] border border-white/10 text-white/55 hover:text-accent-coral hover:bg-white/[0.10] transition'
+            >
+              <svg width='10' height='10' viewBox='0 0 12 12' aria-hidden>
+                <path
+                  d='m3 3 6 6m0-6-6 6'
+                  stroke='currentColor'
+                  strokeWidth='1.6'
+                  strokeLinecap='round'
+                />
+              </svg>
+            </button>
+          )}
+        </div>
+      </div>
+      <ItemBreakdownRows b={b} />
+    </li>
+  )
+}
+
 interface BaseProps {
   items: CartSummaryItem[]
   /** Subtotal + fees + taxes + total computados por `computePricing`. */
@@ -69,6 +117,12 @@ interface BaseProps {
   helperText?: string
   /** Override del título del panel. */
   title?: string
+  /**
+   * Quita el item del carrito. Recibe el `id` del `CartSummaryItem`, que en
+   * asientos es un ticket y en GA es la fila agrupada — cada página decide qué
+   * borra. Sin este prop no se renderiza el botón.
+   */
+  onRemoveItem?: (id: string) => void
 }
 
 const PriceRow = ({
@@ -132,7 +186,8 @@ export const CartSidebar = (props: BaseProps) => {
     onCheckout,
     onBack,
     helperText,
-    title
+    title,
+    onRemoveItem
   } = props
 
   return (
@@ -157,32 +212,9 @@ export const CartSidebar = (props: BaseProps) => {
           <EmptyHint />
         ) : (
           <ul className='space-y-2'>
-            {items.map((item) => {
-              const b = breakdownPerItem(item)
-              return (
-                <li
-                  key={item.id}
-                  className='rounded-glass-sm bg-white/[0.04] border border-white/[0.08] px-3 py-2.5'
-                >
-                  <div className='flex items-start justify-between gap-3'>
-                    <div className='min-w-0 flex-1'>
-                      <div className='font-display text-[12.5px] font-semibold text-white truncate'>
-                        {item.label}
-                      </div>
-                      {item.sublabel && (
-                        <div className='text-[10.5px] text-white/55 mt-0.5 truncate'>
-                          {item.sublabel}
-                        </div>
-                      )}
-                    </div>
-                    <span className='font-display text-[13px] font-bold text-white tabular-nums shrink-0'>
-                      ${b.total.toFixed(2)}
-                    </span>
-                  </div>
-                  <ItemBreakdownRows b={b} />
-                </li>
-              )
-            })}
+            {items.map((item) => (
+              <SummaryItemRow key={item.id} item={item} onRemoveItem={onRemoveItem} />
+            ))}
           </ul>
         )}
         {helperText && items.length > 0 && (
@@ -213,8 +245,18 @@ export const CartSidebar = (props: BaseProps) => {
 }
 
 export const CartMobileSheet = (props: BaseProps) => {
-  const { items, breakdown, count, ctaLabel, ctaDisabled, onCheckout, onBack, helperText, title } =
-    props
+  const {
+    items,
+    breakdown,
+    count,
+    ctaLabel,
+    ctaDisabled,
+    onCheckout,
+    onBack,
+    helperText,
+    title,
+    onRemoveItem
+  } = props
   const [expanded, setExpanded] = useState(false)
   const hasItems = items.length > 0
 
@@ -277,32 +319,9 @@ export const CartMobileSheet = (props: BaseProps) => {
         {expanded && hasItems && (
           <div className='max-h-[50vh] overflow-y-auto border-t border-white/[0.08] px-4 py-3 space-y-3'>
             <ul className='space-y-2'>
-              {items.map((item) => {
-                const b = breakdownPerItem(item)
-                return (
-                  <li
-                    key={item.id}
-                    className='rounded-glass-sm bg-white/[0.04] border border-white/[0.08] px-3 py-2.5'
-                  >
-                    <div className='flex items-start justify-between gap-3'>
-                      <div className='min-w-0 flex-1'>
-                        <div className='font-display text-[12.5px] font-semibold text-white truncate'>
-                          {item.label}
-                        </div>
-                        {item.sublabel && (
-                          <div className='text-[10.5px] text-white/55 mt-0.5 truncate'>
-                            {item.sublabel}
-                          </div>
-                        )}
-                      </div>
-                      <span className='font-display text-[13px] font-bold text-white tabular-nums shrink-0'>
-                        ${b.total.toFixed(2)}
-                      </span>
-                    </div>
-                    <ItemBreakdownRows b={b} />
-                  </li>
-                )
-              })}
+              {items.map((item) => (
+                <SummaryItemRow key={item.id} item={item} onRemoveItem={onRemoveItem} />
+              ))}
             </ul>
 
             <div className='pt-3 border-t border-white/[0.08]'>

--- a/src/components/v2/sale/SeatPickerV2.tsx
+++ b/src/components/v2/sale/SeatPickerV2.tsx
@@ -617,7 +617,8 @@ export default function SeatPickerV2({
           ctaDisabled={disabledCta}
           onCheckout={handleCheckout}
           onBack={onBack}
-          helperText='Tap a selected seat to remove it.'
+          onRemoveItem={removeItem}
+          helperText='Tap a selected seat, or the ×, to remove it.'
         />
       </div>
 
@@ -631,7 +632,8 @@ export default function SeatPickerV2({
         ctaDisabled={disabledCta}
         onCheckout={handleCheckout}
         onBack={onBack}
-        helperText='Tap a selected seat to remove it.'
+        onRemoveItem={removeItem}
+        helperText='Tap a selected seat, or the ×, to remove it.'
       />
     </>
   )

--- a/src/pages/v2/SaleNoSeatsV2.tsx
+++ b/src/pages/v2/SaleNoSeatsV2.tsx
@@ -209,6 +209,13 @@ export default function SaleNoSeatsV2({ event }: SaleNoSeatsV2Props) {
     addItem(item)
   }
 
+  // El × del resumen borra la fila entera; el stepper de la tabla baja de a uno.
+  const removeSummaryRow = (key: string) => {
+    cart
+      .filter((c) => String(c.rowKey ?? c.ticketId) === key)
+      .forEach((c) => removeItem(c.ticketId))
+  }
+
   const decrementRow = (row: TicketRow) => {
     const ofRow = cart.filter((c) => c.rowKey === row.key)
     if (ofRow.length === 0) return
@@ -349,6 +356,7 @@ export default function SaleNoSeatsV2({ event }: SaleNoSeatsV2Props) {
             ctaDisabled={disabledCta}
             onCheckout={handleCheckout}
             onBack={() => navigate(event.detailHref)}
+            onRemoveItem={removeSummaryRow}
           />
         </div>
       </main>
@@ -363,6 +371,7 @@ export default function SaleNoSeatsV2({ event }: SaleNoSeatsV2Props) {
         ctaDisabled={disabledCta}
         onCheckout={handleCheckout}
         onBack={() => navigate(event.detailHref)}
+        onRemoveItem={removeSummaryRow}
       />
     </LayoutV2>
   )


### PR DESCRIPTION
El resumen del flujo de venta (sidebar desktop + bottom sheet mobile) sólo listaba los tickets. Para sacar uno había que volver al mapa y destildar el asiento, y en general admission no había forma de quitar una fila entera.

El `CartDrawer` ya tenía su × por item; esto lleva el mismo control al panel de resumen.

## Cambios
- **`CartSummaryPanel.tsx`** — nuevo prop opcional `onRemoveItem(id)`. Si viene, cada fila renderiza un botón × con el mismo estilo y `aria-label` que el del `CartDrawer`. Sin el prop el panel queda exactamente como antes.
- Las dos vistas del panel (sidebar y bottom sheet) tenían el mismo `<li>` duplicado; se extrae a `SummaryItemRow` para no duplicar también el botón. De ahí el diff grande en un cambio chico.
- **`SeatPickerV2.tsx`** — pasa `removeItem` directo: el `id` del summary item ya es el `ticketId`. El helper text ahora menciona las dos formas de quitar un asiento.
- **`SaleNoSeatsV2.tsx`** — el × borra la fila agrupada completa (`removeSummaryRow`), porque en GA una fila es "2 × General Admission". El stepper de la tabla sigue siendo el que baja de a un ticket.

## Nota
`removeItem` sólo saca el item del carrito y del `localStorage`; no libera el lock en hiEvents. Es el mismo comportamiento que ya tenía destildar el asiento en el mapa — el release lo hace el scheduler al expirar la sesión. No se cambió acá.

## Verificación
- `tsc --noEmit` limpio
- `eslint` sin errores (2 warnings `no-unused-vars` por nombres de parámetro en tipos de función, patrón que ya existe en `cartContext.tsx`)
- `prettier --check` OK
- `yarn build` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)