### PR TITLE
feat(events): ocultar del listado los eventos con show_on_web=false

### DIFF
--- a/src/services/hiEventsAdapter.ts
+++ b/src/services/hiEventsAdapter.ts
@@ -224,7 +224,9 @@ export const hiEventToUIEvent = (hi: HiEventPublic, context: { hero?: boolean } 
 
     ticketUrl: undefined,
     isExternal: false,
-    hidden: false,
+    // show_on_web=false: el panel lo sacó del listado/home. Sigue en `all`, así que
+    // el deep-link (detalle, /sale, cola, checkout) resuelve igual.
+    hidden: hi.show_on_web === false,
     expired,
     requiresQueue: false,
     map: hi.map ?? null,

--- a/src/types/hievents.ts
+++ b/src/types/hievents.ts
@@ -107,6 +107,8 @@ export interface HiEventPublic {
   resale_max_price_percent?: number | null
   resale_seller_fee_percent?: number | null
   resale_buyer_fee_percent?: number | null
+  /** false = oculto del listado/home; sigue accesible por URL directa. Default true. */
+  show_on_web?: boolean | null
   /** Atributos custom PÚBLICos (name/value) — se muestran en "Good to know". */
   attributes?: Array<{ name: string; value: unknown; is_public?: boolean }> | null
   location_details: HiLocationDetails | null


### PR DESCRIPTION
## Qué hace

El panel ya permite marcar un evento LIVE como **no visible en el sitio** (`show_on_web`, toggle "Mostrar en la web" en el modal *Publish Event*). Este PR es la mitad del comprador: el evento sale del listado, del home y de los carruseles, pero **sigue accesible por su URL directa**.

## Cómo

- `types/hievents.ts`: campo `show_on_web` en `HiEventPublic` (lo expone `EventResourcePublic`).
- `services/hiEventsAdapter.ts`: `hidden: hi.show_on_web === false`.

Reusa el flag `hidden` que ya existía en `UIEvent` y que `isVisibleEvent` ya filtraba — de ahí que el diff sean 5 líneas.

## Por qué el deep-link sigue funcionando

`useUIEvents` expone `all` y `visible`. Los listados (`EventsV2`, `HomeV2`, hero, carruseles curados) usan `visible`; el detalle, `/sale`, la cola y el checkout resuelven con `byId`/`byLabel`, que leen de `all`. `EventDetailV2` además tiene fallback al detalle individual (`getEvent`) para deep-links.

## Backend

Ya desplegado en `panel.ticketsaver.net` (columna `events.show_on_web`, default `true`). Sin este PR el campo simplemente se ignora, así que no hay orden de merge obligatorio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)