### PR TITLE
fix(resale): no listar en el mercado los eventos ocultos

### DIFF
--- a/src/pages/v2/ResaleMarketV2.tsx
+++ b/src/pages/v2/ResaleMarketV2.tsx
@@ -38,7 +38,9 @@ export default function ResaleMarketV2() {
     () =>
       resaleEvents
         .map((re) => ({ re, ui: byId(String(re.event_id)) }))
-        .filter((x): x is { re: HiResaleEvent; ui: UIEvent } => Boolean(x.ui)),
+        // `byId` lee de `all`, que incluye los ocultos (show_on_web=false). Este es
+        // un listado, así que se filtran igual que en el home y en /events.
+        .filter((x): x is { re: HiResaleEvent; ui: UIEvent } => Boolean(x.ui) && !x.ui!.hidden),
     [resaleEvents, byId]
   )
 


### PR DESCRIPTION
Hueco que quedó del #65: la página de **Reventa** cruza los eventos con reventa contra el catálogo con `byId`, que lee de `all` — y `all` incluye los `show_on_web=false` a propósito (es lo que hace que el deep-link de compra siga funcionando).

Resultado: un evento oculto con tickets en reventa seguía listado ahí, aunque ya no apareciera ni en el home ni en `/events`.

Una línea: `.filter(... && !x.ui!.hidden)`.

Auditadas el resto de superficies — `EventsV2`, `HomeV2` (hero, carruseles curados, cover-flow, thisWeek/tonight) y `EventDetailV2` ya filtran por `visible`/`!hidden`. Las que resuelven deep-links (`SaleV2`, `QueueV2`, `CheckoutV2`, `ResaleEventV2`, `TicketPublicV2`, `TicketReceivedV2`) usan `all` y deben seguir así.

🤖 Generated with [Claude Code](https://claude.com/claude-code)